### PR TITLE
fix(ci): pass -x and --source-path to shellcheck

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,6 +16,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y shellcheck shfmt
       - name: shellcheck
-        run: shellcheck mosaic.tmux scripts/*.sh scripts/algorithms/*.sh tests/helpers.bash
+        run: shellcheck -x --source-path=SCRIPTDIR --source-path=SCRIPTDIR/scripts mosaic.tmux scripts/*.sh scripts/algorithms/*.sh tests/helpers.bash
       - name: shfmt
         run: shfmt -d mosaic.tmux scripts tests

--- a/justfile
+++ b/justfile
@@ -6,7 +6,7 @@ format:
     shfmt -d mosaic.tmux scripts tests
 
 lint:
-    shellcheck mosaic.tmux scripts/*.sh scripts/algorithms/*.sh tests/helpers.bash
+    shellcheck -x --source-path=SCRIPTDIR --source-path=SCRIPTDIR/scripts mosaic.tmux scripts/*.sh scripts/algorithms/*.sh tests/helpers.bash
 
 test:
     bats tests/integration


### PR DESCRIPTION
Ubuntu's apt-get shellcheck treats SC1091 (info: source not specified as input) as a non-zero exit. The source comments in `ops.sh` / `mosaic.tmux` are relative to each script, so we need both `-x` (follow sources) and `--source-path=SCRIPTDIR` (resolve relative to each file's directory) for shellcheck to actually find them.

Verified locally: `shellcheck -x --source-path=SCRIPTDIR --source-path=SCRIPTDIR/scripts ...` exits 0.