### PR TITLE
fix: sync @mosaic-mfact from pane width on resize

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,16 +110,15 @@ Each algorithm is one file under `scripts/algorithms/<name>.sh` exposing a
 fixed contract:
 
 ```
-algo_relayout <window-id>
-algo_toggle
-algo_focus_next
-algo_focus_prev
-algo_focus_master
-algo_swap_next
-algo_swap_prev
-algo_promote
-algo_resize_master <delta>
-algo_toggle_zoom
+algo_relayout <window-id>          # required
+algo_promote                       # optional
+algo_resize_master <delta>         # optional
+algo_sync_state <window-id>        # optional — sync mosaic state from current tmux state
+algo_toggle                        # optional
+algo_focus_next / algo_focus_prev  # optional (default: select-pane -t :.+/-)
+algo_focus_master                  # optional (default: focus pane at pane-base-index)
+algo_swap_next / algo_swap_prev    # optional (default: swap-pane -D/-U)
+algo_toggle_zoom                   # optional (default: resize-pane -Z)
 ```
 
 The dispatcher (`scripts/ops.sh`) sources the file selected by
@@ -168,9 +167,11 @@ acting. Unset windows are inert.
   strings, but mosaic uses native layouts only and stack heights are always
   equal-split with running remainder.
 
-- **Hooks fire only on tmux events.** External `swap-pane` calls (from
-  another plugin or your own bindings) won't trigger relayout. Run
-  `relayout` explicitly if you need it.
+- **Hooks fire only on tmux's structural events.** mosaic intercepts
+  `after-split-window`, `after-kill-pane`, `pane-exited`, `pane-died`, and
+  `after-resize-pane`. Operations that bypass these (e.g. direct
+  `select-layout` to a non-master-vertical layout, or `move-pane`
+  reordering) won't trigger relayout. Run `relayout` explicitly if needed.
 
 # Acknowledgements
 

--- a/scripts/algorithms/master-stack.sh
+++ b/scripts/algorithms/master-stack.sh
@@ -103,3 +103,27 @@ algo_resize_master() {
 }
 
 algo_toggle_zoom() { tmux resize-pane -Z; }
+
+algo_sync_state() {
+    local win="$1"
+    mosaic_enabled "$win" || return 0
+    [[ "$(tmux display-message -p -t "$win" '#{window_zoomed_flag}')" == "1" ]] && return 0
+
+    local n
+    n=$(tmux list-panes -t "$win" 2>/dev/null | wc -l)
+    [[ "$n" -le 1 ]] && return 0
+
+    local pbase pane_w window_w pct
+    pbase=$(algo_pane_base)
+    pane_w=$(tmux display-message -p -t "$win.$pbase" '#{pane_width}' 2>/dev/null)
+    window_w=$(tmux display-message -p -t "$win" '#{window_width}' 2>/dev/null)
+    [[ -z "$pane_w" ]] && return 0
+    [[ -z "$window_w" || "$window_w" -le 0 ]] && return 0
+
+    pct=$((pane_w * 100 / window_w))
+    [[ "$pct" -lt 5 ]] && pct=5
+    [[ "$pct" -gt 95 ]] && pct=95
+
+    tmux set-option -wq -t "$win" "@mosaic-mfact" "$pct"
+    mosaic_log "sync-state: win=$win pane_w=$pane_w window_w=$window_w pct=$pct"
+}

--- a/scripts/defaults.sh
+++ b/scripts/defaults.sh
@@ -20,4 +20,6 @@ mosaic_register_hooks() {
         "run-shell -b '$exec relayout #{window_id}'"
     tmux set-hook -ga pane-died \
         "run-shell -b '$exec relayout #{window_id}'"
+    tmux set-hook -ga after-resize-pane \
+        "run-shell -b '$exec _sync-state #{window_id}'"
 }

--- a/scripts/ops.sh
+++ b/scripts/ops.sh
@@ -37,7 +37,7 @@ shift || true
 
 WIN_ARG=""
 case "$cmd" in
-relayout)
+relayout | _sync-state)
     WIN_ARG="${1:-}"
     ;;
 esac
@@ -51,6 +51,11 @@ fi
 
 case "$cmd" in
 relayout) algo_relayout "$target_window" ;;
+_sync-state)
+    if declare -f algo_sync_state >/dev/null; then
+        algo_sync_state "$target_window"
+    fi
+    ;;
 toggle) algo_toggle ;;
 focus-next) algo_focus_next ;;
 focus-prev) algo_focus_prev ;;

--- a/tests/integration/master_stack.bats
+++ b/tests/integration/master_stack.bats
@@ -216,3 +216,31 @@ teardown() {
     [ "$status" -ne 0 ]
     [[ "$output" == *"unknown algorithm"* ]]
 }
+
+@test "drag-resize: master width survives next split" {
+    mosaic_split
+    mosaic_t resize-pane -t t:1.1 -x 160
+    sleep 0.2
+    [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "80" ]
+
+    mosaic_split
+    pane_w=$(mosaic_t list-panes -t t:1 -F '#{pane_index} #{pane_width}' | awk '$1==1{print $2}')
+    [ "$pane_w" -ge 158 ]
+    [ "$pane_w" -le 161 ]
+}
+
+@test "drag-resize: zoomed pane does not poison mfact" {
+    mosaic_split
+    mosaic_t resize-pane -t t:1.1 -x 120
+    sleep 0.2
+    [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
+
+    mosaic_t select-pane -t t:1.1
+    mosaic_t resize-pane -Z
+    sleep 0.2
+    [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
+
+    mosaic_t resize-pane -Z
+    sleep 0.2
+    [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
+}


### PR DESCRIPTION
Closes the only real correctness gap from the rigor audit: tmux's mouse drag-resize doesn't update `main-pane-width`, so our next `algo_relayout` was reverting the user's drag.

**Fix:** `after-resize-pane` hook → optional `algo_sync_state` per algorithm. master-stack reads pane #pbase actual width as percent of window width, writes back to `@mosaic-mfact`. Skipped when zoomed.

**Verified empirically** — `after-resize-pane` fires on `resize-pane` but NOT on `select-layout` or `set-window-option main-pane-width`, so no recursion with our own ops.

**Tests:** drag preserves across splits; zoom doesn't poison mfact.

**Bonus:** the algorithm contract grows by one optional method. A `grid` algorithm wouldn't define `algo_sync_state` (no master-width concept) and the dispatcher would correctly no-op.