### PR TITLE
refactor: drop tmux-wrapper ops, document stock alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ no key grabs.
 ## Features
 
 - Hyprland master-layout semantics (verified against `MasterAlgorithm.cpp`)
-- Ring-traversal `swap-next` / `swap-prev` (master ↔ stack-top wraps included)
 - Per-window opt-in — disabled windows are entirely untouched
 - Strategy pattern under `scripts/algorithms/` for adding new layouts
 - Native tmux primitives only — no hand-rolled layout strings, no CRC-16
@@ -63,34 +62,49 @@ Mosaic is **opt-in per window**:
 set-option -wq @mosaic-enabled 1
 ```
 
-Bind whichever ops you want. The plugin exports `@mosaic-exec` so paths
-resolve cleanly across nix-store / TPM / manual installs:
+Stock tmux already covers the trivial ops (focus, swap, zoom). Mosaic
+adds only the operations tmux can't express on its own. The plugin
+exports `@mosaic-exec` so paths resolve cleanly across nix-store / TPM
+/ manual installs:
 
 ```tmux
-bind a run '#{E:@mosaic-exec} focus-next'
-bind f run '#{E:@mosaic-exec} focus-prev'
-bind d run '#{E:@mosaic-exec} swap-next'
-bind u run '#{E:@mosaic-exec} swap-prev'
+# Stock tmux primitives — work the way Hyprland's master layout does
+# because mosaic keeps the layout as main-vertical
+bind a select-pane -t :.+
+bind f select-pane -t :.-
+bind M select-pane -t :.1
+bind d swap-pane -D
+bind u swap-pane -U
+bind z resize-pane -Z
+
+# mosaic value-adds
 bind Enter run '#{E:@mosaic-exec} promote'
 bind -r , run '#{E:@mosaic-exec} resize-master -5'
 bind -r . run '#{E:@mosaic-exec} resize-master +5'
-bind z run '#{E:@mosaic-exec} toggle-zoom'
 bind T run '#{E:@mosaic-exec} toggle'
-bind M run '#{E:@mosaic-exec} focus-master'
 ```
 
 ## Operations
 
+mosaic exposes four operations. Everything else is stock tmux.
+
 | Op | Behavior |
 |---|---|
-| `focus-next` / `focus-prev` | Cycle focus through panes (ring, wraps) |
-| `focus-master` | Focus the master pane |
-| `swap-next` / `swap-prev` | Move focused pane through the layout ring (Hyprland `swapnext` / `swapprev`) |
-| `promote` | Move focused stack pane to master. On master: swap with stack-top |
-| `resize-master ±N` | Adjust master width by N percent (clamped 5–95) |
-| `toggle-zoom` | Tmux native zoom (monocle equivalent) |
 | `toggle` | Enable/disable tiling on the current window |
-| `relayout` | Force re-apply the current algorithm |
+| `promote` | Move focused stack pane to master. On master: swap with stack-top (Hyprland's `swapwithmaster auto`) |
+| `resize-master ±N` | Adjust master width by N percent (clamped 5–95) |
+| `relayout` | Force re-apply the current algorithm (rarely needed — hooks fire on splits, kills, exits, and resizes) |
+
+For the non-master-stack-specific ops, use stock tmux directly:
+
+| Want | Tmux command |
+|---|---|
+| Focus next/prev pane in the ring | `select-pane -t :.+` / `:.-` |
+| Focus the master | `select-pane -t :.1` (or `:.0` if `pane-base-index` is 0) |
+| Swap focused pane through the ring (Hyprland `swapnext` / `swapprev`) | `swap-pane -D` / `-U` |
+| Zoom focused pane (monocle equivalent) | `resize-pane -Z` |
+
+These work because mosaic keeps the layout as `main-vertical`, which positions panes by index. Tmux's index-order ops then traverse the master/stack ring exactly as Hyprland's master layout does.
 
 ## Options
 
@@ -110,15 +124,11 @@ Each algorithm is one file under `scripts/algorithms/<name>.sh` exposing a
 fixed contract:
 
 ```
-algo_relayout <window-id>          # required
-algo_promote                       # optional
-algo_resize_master <delta>         # optional
-algo_sync_state <window-id>        # optional — sync mosaic state from current tmux state
-algo_toggle                        # optional
-algo_focus_next / algo_focus_prev  # optional (default: select-pane -t :.+/-)
-algo_focus_master                  # optional (default: focus pane at pane-base-index)
-algo_swap_next / algo_swap_prev    # optional (default: swap-pane -D/-U)
-algo_toggle_zoom                   # optional (default: resize-pane -Z)
+algo_relayout <window-id>      # required — apply the layout
+algo_toggle                    # required — enable/disable on this window
+algo_promote                   # optional — bring focused pane to "primary" slot
+algo_resize_master <delta>     # optional — adjust the algorithm's primary dimension
+algo_sync_state <window-id>    # optional — pull mosaic state from current tmux state
 ```
 
 The dispatcher (`scripts/ops.sh`) sources the file selected by

--- a/scripts/algorithms/master-stack.sh
+++ b/scripts/algorithms/master-stack.sh
@@ -57,20 +57,6 @@ algo_toggle() {
     fi
 }
 
-algo_focus_next() { tmux select-pane -t :.+; }
-algo_focus_prev() { tmux select-pane -t :.-; }
-algo_focus_master() { tmux select-pane -t ":.$(algo_pane_base)"; }
-
-algo_swap_next() {
-    [[ "$(algo_pane_count)" -le 1 ]] && return 0
-    tmux swap-pane -D
-}
-
-algo_swap_prev() {
-    [[ "$(algo_pane_count)" -le 1 ]] && return 0
-    tmux swap-pane -U
-}
-
 algo_promote() {
     local idx n pbase
     idx=$(algo_pane_index)
@@ -101,8 +87,6 @@ algo_resize_master() {
     tmux set-option -wq -t "$win" "@mosaic-mfact" "$new"
     algo_relayout "$win"
 }
-
-algo_toggle_zoom() { tmux resize-pane -Z; }
 
 algo_sync_state() {
     local win="$1"

--- a/scripts/ops.sh
+++ b/scripts/ops.sh
@@ -49,22 +49,22 @@ if ! load_algorithm "$algo"; then
     exit 1
 fi
 
+dispatch_optional() {
+    local fn="$1"
+    shift
+    if declare -f "$fn" >/dev/null; then
+        "$fn" "$@"
+    else
+        tmux display-message "mosaic: $algo does not implement ${fn#algo_}"
+    fi
+}
+
 case "$cmd" in
 relayout) algo_relayout "$target_window" ;;
-_sync-state)
-    if declare -f algo_sync_state >/dev/null; then
-        algo_sync_state "$target_window"
-    fi
-    ;;
 toggle) algo_toggle ;;
-focus-next) algo_focus_next ;;
-focus-prev) algo_focus_prev ;;
-focus-master) algo_focus_master ;;
-swap-next) algo_swap_next ;;
-swap-prev) algo_swap_prev ;;
-promote) algo_promote ;;
-resize-master) algo_resize_master "$@" ;;
-toggle-zoom) algo_toggle_zoom ;;
+_sync-state) dispatch_optional algo_sync_state "$target_window" ;;
+promote) dispatch_optional algo_promote ;;
+resize-master) dispatch_optional algo_resize_master "$@" ;;
 '')
     echo "usage: $0 <op> [args]" >&2
     exit 1

--- a/tests/integration/master_stack.bats
+++ b/tests/integration/master_stack.bats
@@ -55,34 +55,6 @@ teardown() {
     [ "${diff#-}" -le 1 ]
 }
 
-@test "swap-next ring: master cycles through stack and back" {
-    for _ in 1 2 3; do mosaic_split; done
-    mosaic_t select-pane -t t:1.1
-    pid=$(mosaic_t display-message -p -t t:1 '#{pane_id}')
-
-    for expected_idx in 2 3 4 1; do
-        mosaic_op swap-next
-        actual_idx=$(mosaic_pane_index)
-        actual_pid=$(mosaic_t display-message -p -t t:1 '#{pane_id}')
-        [ "$actual_pid" = "$pid" ]
-        [ "$actual_idx" = "$expected_idx" ]
-    done
-}
-
-@test "swap-prev ring: master jumps to last slave, walks back" {
-    for _ in 1 2 3; do mosaic_split; done
-    mosaic_t select-pane -t t:1.1
-    pid=$(mosaic_t display-message -p -t t:1 '#{pane_id}')
-
-    for expected_idx in 4 3 2 1; do
-        mosaic_op swap-prev
-        actual_idx=$(mosaic_pane_index)
-        actual_pid=$(mosaic_t display-message -p -t t:1 '#{pane_id}')
-        [ "$actual_pid" = "$pid" ]
-        [ "$actual_idx" = "$expected_idx" ]
-    done
-}
-
 @test "promote from stack: focused pane becomes master" {
     for _ in 1 2 3; do mosaic_split; done
     mosaic_t select-pane -t t:1.3
@@ -102,29 +74,6 @@ teardown() {
     mosaic_op promote
     [ "$(mosaic_pane_id_at t:1.1)" = "$stack_top_pid" ]
     [ "$(mosaic_pane_id_at t:1.2)" = "$master_pid" ]
-}
-
-@test "focus-next/prev cycle through ring" {
-    for _ in 1 2 3; do mosaic_split; done
-    mosaic_t select-pane -t t:1.1
-    [ "$(mosaic_pane_index)" = "1" ]
-
-    for expected in 2 3 4 1; do
-        mosaic_op focus-next
-        [ "$(mosaic_pane_index)" = "$expected" ]
-    done
-
-    for expected in 4 3 2 1; do
-        mosaic_op focus-prev
-        [ "$(mosaic_pane_index)" = "$expected" ]
-    done
-}
-
-@test "focus-master jumps to pane 1" {
-    for _ in 1 2 3; do mosaic_split; done
-    mosaic_t select-pane -t t:1.4
-    mosaic_op focus-master
-    [ "$(mosaic_pane_index)" = "1" ]
 }
 
 @test "resize-master adjusts mfact (window-scoped) and clamps" {
@@ -182,15 +131,6 @@ teardown() {
     [ "$(mosaic_pane_id_at t:1.1)" = "$stack_top" ]
     layout=$(mosaic_layout)
     [[ "$layout" == *"{"* ]]
-}
-
-@test "toggle-zoom toggles window_zoomed_flag" {
-    mosaic_split
-    [ "$(mosaic_t display-message -p -t t:1 '#{window_zoomed_flag}')" = "0" ]
-    mosaic_op toggle-zoom
-    [ "$(mosaic_t display-message -p -t t:1 '#{window_zoomed_flag}')" = "1" ]
-    mosaic_op toggle-zoom
-    [ "$(mosaic_t display-message -p -t t:1 '#{window_zoomed_flag}')" = "0" ]
 }
 
 @test "disabled window: splits do NOT retile" {


### PR DESCRIPTION
Audit-driven cleanup. Six dispatcher ops were thin wrappers around stock tmux commands adding zero value:

- `focus-next` / `focus-prev` → just `select-pane -t :.+/-`
- `focus-master` → just `select-pane -t :.1`
- `swap-next` / `swap-prev` → just `swap-pane -D/-U` (we discovered tmux's swap-pane natively implements the Hyprland ring)
- `toggle-zoom` → just `resize-pane -Z`

These routed user keypresses through `@mosaic-exec` for nothing — opaque indirection, larger surface area, larger algorithm contract.

mosaic's surface is now four ops: `toggle`, `promote`, `resize-master`, `relayout` (+ internal `_sync-state` for drag handling). The stock tmux ops work as Hyprland's master layout because mosaic keeps the layout as `main-vertical` and tmux's index-order operations naturally walk the master/stack ring.

Dispatcher also tightened: optional ops (`promote`, `resize-master`, `sync-state`) go through `dispatch_optional` which checks `declare -f` and surfaces a friendly error via `display-message` if the active algorithm doesn't implement them. Makes the README's 'optional contract methods' claim actually true.

README rewritten: ops table from 8 rows to 4, with a separate 'just use tmux' table pointing at the stock alternatives.

Tests: 21 → 16 (the 5 deleted tests were testing tmux itself, not mosaic — the invariants that make those ops correct are still exercised).