### PR TITLE
feat(release): automate nightly and stable releases

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,8 +4,12 @@ changelog:
       - duplicate
       - invalid
       - question
+      - skip-release-notes
       - wontfix
   categories:
+    - title: Breaking Changes
+      labels:
+        - breaking-change
     - title: Features
       labels:
         - enhancement

--- a/.github/workflows/automation_release_metadata.yaml
+++ b/.github/workflows/automation_release_metadata.yaml
@@ -1,0 +1,92 @@
+name: Release Metadata
+
+on:
+  pull_request_target:
+    types: [opened, reopened, edited, synchronize, labeled, unlabeled, ready_for_review]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  release_metadata:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const managedLabels = [
+              {
+                name: 'breaking-change',
+                color: 'B60205',
+                description: 'Change that breaks documented user-facing behavior',
+              },
+              {
+                name: 'skip-release-notes',
+                color: 'cfd3d7',
+                description: 'Exclude from generated release notes',
+              },
+            ];
+            for (const label of managedLabels) {
+              try {
+                await github.rest.issues.getLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name,
+                });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name,
+                  color: label.color,
+                  description: label.description,
+                });
+              }
+            }
+            const issue = context.payload.pull_request;
+            const releaseLabels = new Set(['breaking-change', 'enhancement', 'bug', 'documentation']);
+            const body = issue.body || '';
+            const refs = new Set();
+            const pattern = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+(?:(?<owner>[A-Za-z0-9_.-]+)\/(?<repo>[A-Za-z0-9_.-]+))?#(?<number>\d+)/gi;
+            for (const match of body.matchAll(pattern)) {
+              const owner = match.groups?.owner;
+              const repo = match.groups?.repo;
+              if (owner && repo && (owner !== context.repo.owner || repo !== context.repo.repo)) continue;
+              refs.add(Number(match.groups.number));
+            }
+            const add = new Set();
+            for (const number of refs) {
+              try {
+                const linked = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: number,
+                });
+                for (const label of linked.data.labels) {
+                  const name = typeof label === 'string' ? label : label.name;
+                  if (releaseLabels.has(name)) add.add(name);
+                }
+              } catch (error) {
+                if (error.status !== 404) throw error;
+              }
+            }
+            const current = new Set(issue.labels.map(label => label.name));
+            const toAdd = [...add].filter(name => !current.has(name));
+            if (toAdd.length) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: toAdd,
+              });
+              for (const name of toAdd) current.add(name);
+            }
+            const selected = [...current].filter(name => releaseLabels.has(name));
+            if (current.has('skip-release-notes') && selected.length) {
+              core.setFailed('skip-release-notes cannot be combined with a release category label');
+            }
+            if (selected.length > 1) {
+              core.setFailed(`pull request has multiple release category labels: ${selected.join(', ')}`);
+            }

--- a/.github/workflows/release_nightly.yaml
+++ b/.github/workflows/release_nightly.yaml
@@ -1,0 +1,91 @@
+name: Nightly Release
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 5 * * *'
+
+permissions:
+  actions: read
+  contents: write
+
+concurrency:
+  group: nightly-release
+  cancel-in-progress: false
+
+jobs:
+  nightly_release:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Resolve latest green main commit
+        id: run
+        run: |
+          sha="$(gh run list --repo "$GITHUB_REPOSITORY" --workflow quality --branch main --event push --json headSha,conclusion,status --limit 20 | jq -r 'map(select(.status == "completed" and .conclusion == "success")) | .[0].headSha // empty')"
+          [ -n "$sha" ]
+          echo "head_sha=$sha" >>"$GITHUB_OUTPUT"
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.run.outputs.head_sha }}
+      - name: Resolve nightly state
+        id: state
+        run: |
+          git fetch --tags origin
+          version="$(scripts/release-version.sh get)"
+          if ! scripts/release-version.sh assert-dev "$version" >/dev/null 2>&1; then
+            echo "publish=false" >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
+          short_sha="${{ steps.run.outputs.head_sha }}"
+          short_sha="${short_sha:0:7}"
+          title="nightly ($version, $(date -u +%Y-%m-%d), $short_sha)"
+          previous_tag="$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n 1 || true)"
+          current="$(git ls-remote --tags origin 'refs/tags/nightly^{}' | awk '{print $1}')"
+          if [ -z "$current" ]; then
+            current="$(git ls-remote --tags origin 'refs/tags/nightly' | awk '{print $1}')"
+          fi
+          if [ "$current" = "${{ steps.run.outputs.head_sha }}" ]; then
+            echo "publish=false" >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
+          {
+            echo "publish=true"
+            echo "version=$version"
+            echo "previous_tag=$previous_tag"
+            echo "title=$title"
+          } >>"$GITHUB_OUTPUT"
+      - name: Generate nightly notes
+        if: steps.state.outputs.publish == 'true'
+        run: |
+          if [ -n "${{ steps.state.outputs.previous_tag }}" ]; then
+            gh api -X POST "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
+              -f tag_name=nightly \
+              -f target_commitish="${{ steps.run.outputs.head_sha }}" \
+              -f previous_tag_name="${{ steps.state.outputs.previous_tag }}" >"$RUNNER_TEMP/nightly-notes.json"
+          else
+            gh api -X POST "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
+              -f tag_name=nightly \
+              -f target_commitish="${{ steps.run.outputs.head_sha }}" >"$RUNNER_TEMP/nightly-notes.json"
+          fi
+          printf "Built from \`%s\`.\n\n" "${{ steps.run.outputs.head_sha }}" >"$RUNNER_TEMP/nightly-notes.md"
+          jq -r '.body' "$RUNNER_TEMP/nightly-notes.json" >>"$RUNNER_TEMP/nightly-notes.md"
+      - name: Create or update nightly release
+        if: steps.state.outputs.publish == 'true'
+        run: |
+          if gh release view nightly --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release delete nightly --repo "$GITHUB_REPOSITORY" -y
+          fi
+          git push origin :refs/tags/nightly || true
+          GIT_COMMITTER_NAME='github-actions[bot]' \
+          GIT_COMMITTER_EMAIL='41898282+github-actions[bot]@users.noreply.github.com' \
+          git tag -a nightly "${{ steps.run.outputs.head_sha }}" -m nightly
+          git push --force origin refs/tags/nightly
+          gh release create nightly \
+            --repo "$GITHUB_REPOSITORY" \
+            --verify-tag \
+            --title "${{ steps.state.outputs.title }}" \
+            --notes-file "$RUNNER_TEMP/nightly-notes.md" \
+            --prerelease \
+            --latest=false

--- a/.github/workflows/release_nightly.yaml
+++ b/.github/workflows/release_nightly.yaml
@@ -2,8 +2,9 @@ name: Nightly Release
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '17 5 * * *'
+  workflow_run:
+    workflows: ["quality"]
+    types: [completed]
 
 permissions:
   actions: read
@@ -11,18 +12,23 @@ permissions:
 
 concurrency:
   group: nightly-release
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   nightly_release:
+    if: github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main')
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - name: Resolve latest green main commit
+      - name: Resolve target commit
         id: run
         run: |
-          sha="$(gh run list --repo "$GITHUB_REPOSITORY" --workflow quality --branch main --event push --json headSha,conclusion,status --limit 20 | jq -r 'map(select(.status == "completed" and .conclusion == "success")) | .[0].headSha // empty')"
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            sha="${{ github.event.workflow_run.head_sha }}"
+          else
+            sha="$(gh run list --repo "$GITHUB_REPOSITORY" --workflow quality --branch main --event push --json headSha,conclusion,status --limit 20 | jq -r 'map(select(.status == "completed" and .conclusion == "success")) | .[0].headSha // empty')"
+          fi
           [ -n "$sha" ]
           echo "head_sha=$sha" >>"$GITHUB_OUTPUT"
       - uses: actions/checkout@v4
@@ -40,7 +46,7 @@ jobs:
           fi
           short_sha="${{ steps.run.outputs.head_sha }}"
           short_sha="${short_sha:0:7}"
-          title="nightly ($version, $(date -u +%Y-%m-%d), $short_sha)"
+          title="Nightly $version ($short_sha)"
           previous_tag="$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n 1 || true)"
           current="$(git ls-remote --tags origin 'refs/tags/nightly^{}' | awk '{print $1}')"
           if [ -z "$current" ]; then

--- a/.github/workflows/release_prepare.yaml
+++ b/.github/workflows/release_prepare.yaml
@@ -1,0 +1,85 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Stable version to release
+        required: true
+        type: string
+      next_dev_version:
+        description: Version to put on main after the stable release
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  prepare_release:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      VERSION: ${{ inputs.version }}
+      NEXT_DEV_VERSION: ${{ inputs.next_dev_version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const label = {
+              name: 'skip-release-notes',
+              color: 'cfd3d7',
+              description: 'Exclude from generated release notes',
+            };
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label.name,
+              });
+            } catch (error) {
+              if (error.status !== 404) throw error;
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label.name,
+                color: label.color,
+                description: label.description,
+              });
+            }
+      - name: Validate versions
+        run: |
+          current="$(scripts/release-version.sh get)"
+          scripts/release-version.sh assert-dev "$current"
+          scripts/release-version.sh assert-stable "$VERSION"
+          scripts/release-version.sh assert-dev "$NEXT_DEV_VERSION"
+          base="$(scripts/release-version.sh base "$current")"
+          [ "$base" = "$VERSION" ]
+          [ "$current" != "$NEXT_DEV_VERSION" ]
+      - name: Update flake version
+        run: scripts/release-version.sh set "$VERSION"
+      - name: Commit release branch
+        run: |
+          branch="release/v$VERSION"
+          git checkout -B "$branch"
+          git add flake.nix
+          git -c user.name='github-actions[bot]' -c user.email='41898282+github-actions[bot]@users.noreply.github.com' commit -m "chore(release): prepare v$VERSION"
+          git push --force-with-lease origin "$branch"
+      - name: Open or update release PR
+        run: |
+          branch="release/v$VERSION"
+          title="chore(release): prepare v$VERSION"
+          body="$(mktemp)"
+          printf 'release-version: %s\nnext-dev-version: %s\n' "$VERSION" "$NEXT_DEV_VERSION" >"$body"
+          pr="$(gh pr list --base main --head "$branch" --state open --json number --jq '.[0].number // empty')"
+          if [ -n "$pr" ]; then
+            gh pr edit "$pr" --title "$title" --body-file "$body" --add-label skip-release-notes
+          else
+            gh pr create --base main --head "$branch" --title "$title" --body-file "$body" --label skip-release-notes
+          fi
+          rm -f "$body"

--- a/.github/workflows/release_publish.yaml
+++ b/.github/workflows/release_publish.yaml
@@ -1,0 +1,128 @@
+name: Publish Release
+
+on:
+  workflow_run:
+    workflows: ["quality"]
+    types: [completed]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: release-publish-main
+  cancel-in-progress: false
+
+jobs:
+  publish_release:
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha }}
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const label = {
+              name: 'skip-release-notes',
+              color: 'cfd3d7',
+              description: 'Exclude from generated release notes',
+            };
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label.name,
+              });
+            } catch (error) {
+              if (error.status !== 404) throw error;
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label.name,
+                color: label.color,
+                description: label.description,
+              });
+            }
+      - name: Resolve release state
+        id: state
+        run: |
+          git fetch origin main --tags
+          version="$(scripts/release-version.sh get)"
+          if ! scripts/release-version.sh assert-stable "$version" >/dev/null 2>&1; then
+            echo "publish=false" >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
+          tag="$(scripts/release-version.sh tag "$version")"
+          prs="$(gh api "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA/pulls")"
+          next_dev="$(printf '%s' "$prs" | jq -r '.[0].body // ""' | awk -F': *' '/^next-dev-version:/ { print $2; exit }')"
+          if ! scripts/release-version.sh assert-dev "$next_dev" >/dev/null 2>&1; then
+            next_dev="$(scripts/release-version.sh next-patch-dev "$version")"
+          fi
+          previous_tag="$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n 1 || true)"
+          current_main_version="$(git show origin/main:flake.nix | awk -F'\"' '/version = \"/ { print $2; exit }')"
+          {
+            echo "publish=true"
+            echo "version=$version"
+            echo "tag=$tag"
+            echo "next_dev=$next_dev"
+            echo "previous_tag=$previous_tag"
+            echo "current_main_version=$current_main_version"
+          } >>"$GITHUB_OUTPUT"
+      - name: Generate release notes
+        if: steps.state.outputs.publish == 'true'
+        run: |
+          if [ -n "${{ steps.state.outputs.previous_tag }}" ]; then
+            gh api -X POST "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
+              -f tag_name="${{ steps.state.outputs.tag }}" \
+              -f target_commitish="$HEAD_SHA" \
+              -f previous_tag_name="${{ steps.state.outputs.previous_tag }}" >"$RUNNER_TEMP/release-notes.json"
+          else
+            gh api -X POST "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
+              -f tag_name="${{ steps.state.outputs.tag }}" \
+              -f target_commitish="$HEAD_SHA" >"$RUNNER_TEMP/release-notes.json"
+          fi
+          jq -r '.body' "$RUNNER_TEMP/release-notes.json" >"$RUNNER_TEMP/release-notes.md"
+      - name: Create or update stable release
+        if: steps.state.outputs.publish == 'true'
+        run: |
+          if ! git ls-remote --exit-code --tags origin "refs/tags/${{ steps.state.outputs.tag }}" >/dev/null 2>&1; then
+            GIT_COMMITTER_NAME='github-actions[bot]' \
+            GIT_COMMITTER_EMAIL='41898282+github-actions[bot]@users.noreply.github.com' \
+            git tag -a "${{ steps.state.outputs.tag }}" "$HEAD_SHA" -m "${{ steps.state.outputs.tag }}"
+            git push origin "refs/tags/${{ steps.state.outputs.tag }}"
+          fi
+          if gh release view "${{ steps.state.outputs.tag }}" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release edit "${{ steps.state.outputs.tag }}" --repo "$GITHUB_REPOSITORY" --title "${{ steps.state.outputs.tag }}" --notes-file "$RUNNER_TEMP/release-notes.md"
+          else
+            gh release create "${{ steps.state.outputs.tag }}" \
+              --repo "$GITHUB_REPOSITORY" \
+              --verify-tag \
+              --title "${{ steps.state.outputs.tag }}" \
+              --notes-file "$RUNNER_TEMP/release-notes.md"
+          fi
+      - name: Open or update next dev PR
+        if: steps.state.outputs.publish == 'true' && steps.state.outputs.current_main_version == steps.state.outputs.version
+        run: |
+          branch="release/next-${{ steps.state.outputs.next_dev }}"
+          title="chore(release): start ${{ steps.state.outputs.next_dev }}"
+          body="$(mktemp)"
+          printf 'released-version: %s\nnext-dev-version: %s\n' "${{ steps.state.outputs.version }}" "${{ steps.state.outputs.next_dev }}" >"$body"
+          git checkout -B "$branch" "$HEAD_SHA"
+          scripts/release-version.sh set "${{ steps.state.outputs.next_dev }}"
+          git add flake.nix
+          git -c user.name='github-actions[bot]' -c user.email='41898282+github-actions[bot]@users.noreply.github.com' commit -m "chore(release): start ${{ steps.state.outputs.next_dev }}"
+          git push --force-with-lease origin "$branch"
+          pr="$(gh pr list --base main --head "$branch" --state open --json number --jq '.[0].number // empty')"
+          if [ -n "$pr" ]; then
+            gh pr edit "$pr" --title "$title" --body-file "$body" --add-label skip-release-notes
+          else
+            gh pr create --base main --head "$branch" --title "$title" --body-file "$body" --label skip-release-notes
+          fi
+          rm -f "$body"

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
       packages = forEachSystem (pkgs: {
         default = pkgs.tmuxPlugins.mkTmuxPlugin {
           pluginName = "mosaic";
-          version = "0.0.1";
+          version = "0.1.0-dev";
           rtpFilePath = "mosaic.tmux";
           src = pkgs.lib.cleanSourceWith {
             src = ./.;

--- a/scripts/release-version.sh
+++ b/scripts/release-version.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FLAKE_FILE="${MOSAIC_FLAKE_FILE:-$ROOT_DIR/flake.nix}"
+
+usage() {
+  echo "usage: $0 <get|set|assert-stable|assert-dev|next-patch-dev|tag|base> [version]" >&2
+}
+
+read_version() {
+  local version
+  version="$(awk -F'"' '/version = "/ { print $2; exit }' "$FLAKE_FILE")"
+  [[ -n "$version" ]] || {
+    echo "mosaic: could not read version from $FLAKE_FILE" >&2
+    return 1
+  }
+  echo "$version"
+}
+
+is_stable() {
+  [[ "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+}
+
+is_dev() {
+  [[ "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+-dev$ ]]
+}
+
+assert_stable() {
+  is_stable "$1" || {
+    echo "mosaic: expected stable semver, got $1" >&2
+    return 1
+  }
+}
+
+assert_dev() {
+  is_dev "$1" || {
+    echo "mosaic: expected dev semver, got $1" >&2
+    return 1
+  }
+}
+
+set_version() {
+  local target="$1" current tmp
+  current="$(read_version)"
+  tmp="$(mktemp)"
+  awk -v current="$current" -v target="$target" '
+    BEGIN { done = 0 }
+    {
+      if (!done) {
+        pattern = "version = \"" current "\";"
+        replacement = "version = \"" target "\";"
+        if (index($0, pattern)) {
+          sub(pattern, replacement)
+          done = 1
+        }
+      }
+      print
+    }
+    END { if (!done) exit 1 }
+  ' "$FLAKE_FILE" >"$tmp"
+  cat "$tmp" >"$FLAKE_FILE"
+  rm -f "$tmp"
+}
+
+base_version() {
+  local version="$1"
+  if is_dev "$version"; then
+    echo "${version%-dev}"
+  else
+    echo "$version"
+  fi
+}
+
+next_patch_dev() {
+  local major minor patch
+  assert_stable "$1"
+  IFS=. read -r major minor patch <<<"$1"
+  echo "$major.$minor.$((patch + 1))-dev"
+}
+
+release_tag() {
+  assert_stable "$1"
+  echo "v$1"
+}
+
+cmd="${1:-}"
+arg="${2:-}"
+
+case "$cmd" in
+get)
+  read_version
+  ;;
+set)
+  [[ -n "$arg" ]] || {
+    usage
+    exit 1
+  }
+  set_version "$arg"
+  ;;
+assert-stable)
+  assert_stable "${arg:-$(read_version)}"
+  ;;
+assert-dev)
+  assert_dev "${arg:-$(read_version)}"
+  ;;
+next-patch-dev)
+  next_patch_dev "${arg:-$(read_version)}"
+  ;;
+tag)
+  release_tag "${arg:-$(read_version)}"
+  ;;
+base)
+  base_version "${arg:-$(read_version)}"
+  ;;
+*)
+  usage
+  exit 1
+  ;;
+esac

--- a/tests/integration/release_version.bats
+++ b/tests/integration/release_version.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+
+load '../helpers.bash'
+
+RELEASE_SCRIPT="$REPO_ROOT/scripts/release-version.sh"
+
+setup() {
+  cat >"$BATS_TEST_TMPDIR/flake.nix" <<'EOF'
+{
+  packages = {
+    default = {
+      version = "0.1.0-dev";
+    };
+  };
+}
+EOF
+}
+
+@test "release-version: get prints the current version" {
+  run env MOSAIC_FLAKE_FILE="$BATS_TEST_TMPDIR/flake.nix" "$RELEASE_SCRIPT" get
+  [ "$status" -eq 0 ]
+  [ "$output" = "0.1.0-dev" ]
+}
+
+@test "release-version: set rewrites the flake version" {
+  run env MOSAIC_FLAKE_FILE="$BATS_TEST_TMPDIR/flake.nix" "$RELEASE_SCRIPT" set 0.1.0
+  [ "$status" -eq 0 ]
+
+  run env MOSAIC_FLAKE_FILE="$BATS_TEST_TMPDIR/flake.nix" "$RELEASE_SCRIPT" get
+  [ "$status" -eq 0 ]
+  [ "$output" = "0.1.0" ]
+}
+
+@test "release-version: assert-dev accepts dev versions" {
+  run env MOSAIC_FLAKE_FILE="$BATS_TEST_TMPDIR/flake.nix" "$RELEASE_SCRIPT" assert-dev 0.1.0-dev
+  [ "$status" -eq 0 ]
+}
+
+@test "release-version: assert-dev rejects stable versions" {
+  run env MOSAIC_FLAKE_FILE="$BATS_TEST_TMPDIR/flake.nix" "$RELEASE_SCRIPT" assert-dev 0.1.0
+  [ "$status" -ne 0 ]
+}
+
+@test "release-version: assert-stable accepts stable versions" {
+  run env MOSAIC_FLAKE_FILE="$BATS_TEST_TMPDIR/flake.nix" "$RELEASE_SCRIPT" assert-stable 0.1.0
+  [ "$status" -eq 0 ]
+}
+
+@test "release-version: base strips dev suffix" {
+  run env MOSAIC_FLAKE_FILE="$BATS_TEST_TMPDIR/flake.nix" "$RELEASE_SCRIPT" base 0.1.0-dev
+  [ "$status" -eq 0 ]
+  [ "$output" = "0.1.0" ]
+}
+
+@test "release-version: next-patch-dev increments patch" {
+  run env MOSAIC_FLAKE_FILE="$BATS_TEST_TMPDIR/flake.nix" "$RELEASE_SCRIPT" next-patch-dev 0.1.0
+  [ "$status" -eq 0 ]
+  [ "$output" = "0.1.1-dev" ]
+}
+
+@test "release-version: tag adds the v prefix" {
+  run env MOSAIC_FLAKE_FILE="$BATS_TEST_TMPDIR/flake.nix" "$RELEASE_SCRIPT" tag 0.1.0
+  [ "$status" -eq 0 ]
+  [ "$output" = "v0.1.0" ]
+}


### PR DESCRIPTION
Why: #12 needs real release automation rather than a manual process or a checked-in changelog. The maintainer flow should be merge normal PRs, let nightly publish itself from each green `main` commit, and use one release-prep action to cut a stable version and hand off the tag, GitHub Release, and next-dev follow-up automatically.

How: This moves `main` to `0.1.0-dev`, adds `.github/release.yml` for generated release-note categories, adds PR metadata automation that syncs release labels from linked issues and rejects conflicting release labels, adds a rolling nightly workflow that republishes `nightly` on every successful `quality` run for `main`, and adds prepare/publish workflows that open the release PR, publish the stable tag and GitHub Release from the green merge commit, and open the follow-up next-dev PR. It also adds a tested `scripts/release-version.sh` helper that the workflows share. Closes #12.
