### PR TITLE
feat(algorithm): add even-vertical

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,11 @@ Faithful to Hyprland's master layout with `nmaster=1`, `new_status=slave`,
 matches `MasterAlgorithm::getNextTarget` — same-category neighbor first,
 falls back across the master/stack boundary at the ring edges.
 
+### even-vertical
+
+Equal-height panes in a column via tmux's native `even-vertical` layout. Set
+`@mosaic-algorithm` to `even-vertical` on a window to use it.
+
 ## FAQ
 
 **Q: Why doesn't `promote` toggle when I'm already master?**

--- a/justfile
+++ b/justfile
@@ -17,7 +17,7 @@ lint: shellcheck
     @:
 
 test:
-    bats tests/integration
+    bats tests/integration/*.bats
 
 build:
     nix build .#default

--- a/scripts/algorithms/even-vertical.sh
+++ b/scripts/algorithms/even-vertical.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+algo_relayout() {
+  local win="${1:-}"
+  [[ -z "$win" ]] && win=$(tmux display-message -p '#{window_id}')
+
+  if ! mosaic_enabled "$win"; then
+    mosaic_log "relayout: disabled on $win, skipping"
+    return 0
+  fi
+
+  local n
+  n=$(tmux list-panes -t "$win" 2>/dev/null | wc -l)
+  [[ "$n" -le 1 ]] && return 0
+
+  tmux select-layout -t "$win" even-vertical 2>/dev/null || true
+
+  mosaic_log "relayout: win=$win n=$n"
+}
+
+algo_toggle() {
+  local win
+  win=$(tmux display-message -p '#{window_id}')
+  if mosaic_enabled "$win"; then
+    tmux set-option -wqu -t "$win" "@mosaic-enabled" 2>/dev/null
+    tmux display-message "mosaic: off"
+  else
+    tmux set-option -wq -t "$win" "@mosaic-enabled" 1
+    tmux display-message "mosaic: on"
+    algo_relayout "$win"
+  fi
+}

--- a/tests/integration/even_vertical.bats
+++ b/tests/integration/even_vertical.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+
+load '../helpers.bash'
+
+setup() {
+  mosaic_setup_server
+  mosaic_t set-option -wq -t t:1 "@mosaic-algorithm" "even-vertical"
+  mosaic_enable
+}
+
+teardown() {
+  mosaic_teardown_server
+}
+
+@test "even-vertical: 4 panes are arranged in an equal-height column" {
+  for _ in 1 2 3; do mosaic_split; done
+  [ "$(mosaic_pane_count)" = "4" ]
+
+  layout=$(mosaic_layout)
+  [[ "$layout" == *"["* ]]
+  [[ "$layout" != *"{"* ]]
+
+  heights=$(mosaic_t list-panes -t t:1 -F '#{pane_height}' | sort -n)
+  min=$(printf '%s\n' "$heights" | head -n1)
+  max=$(printf '%s\n' "$heights" | tail -n1)
+
+  [ $((max - min)) -le 1 ]
+}


### PR DESCRIPTION
This adds an `even-vertical` algorithm backed by tmux's native `even-vertical` layout and documents it in the README. Since tmux's native layout stacks panes as an equal-height column, the new integration test asserts that behavior directly.

I also switched `just test` to `bats tests/integration/*.bats`. Directory mode was fine with a single file, but it wasn't isolating multiple integration files cleanly here, so the repo's normal test surface needed to run the files explicitly once a second integration file landed.

Verified locally with `just ci` and `just build` in the `.#ci` shell.

Closes #8.
