### PR TITLE
feat(algorithm): add master-stack orientation knob

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ mosaic exposes four operations. Everything else is stock tmux.
 |---|---|
 | `toggle` | Enable/disable tiling on the current window |
 | `promote` | Move focused stack pane to master. On master: swap with stack-top (Hyprland's `swapwithmaster auto`) |
-| `resize-master ±N` | Adjust master width by N percent (clamped 5–95) |
+| `resize-master ±N` | Adjust master size by N percent (clamped 5–95) |
 | `relayout` | Force re-apply the current algorithm (rarely needed — hooks fire on splits, kills, exits, and resizes) |
 
 For the non-master-stack-specific ops, use stock tmux directly:
@@ -104,7 +104,7 @@ For the non-master-stack-specific ops, use stock tmux directly:
 | Swap focused pane through the ring (Hyprland `swapnext` / `swapprev`) | `swap-pane -D` / `-U` |
 | Zoom focused pane (monocle equivalent) | `resize-pane -Z` |
 
-These work because mosaic keeps the layout as `main-vertical`, which positions panes by index. Tmux's index-order ops then traverse the master/stack ring exactly as Hyprland's master layout does.
+These work because mosaic keeps the layout in tmux's `main-*` family, which positions panes by index and keeps pane 1 as the master. Tmux's index-order ops then traverse the master/stack ring exactly as Hyprland's master layout does.
 
 ## Options
 
@@ -113,7 +113,8 @@ These work because mosaic keeps the layout as `main-vertical`, which positions p
 | `@mosaic-enabled` | window | unset | Set to `1` to tile this window |
 | `@mosaic-algorithm` | window | (uses default) | Per-window algorithm override |
 | `@mosaic-default-algorithm` | global | `master-stack` | Default for windows without override |
-| `@mosaic-mfact` | window→global | `50` | Master width as percent (window-scoped value wins) |
+| `@mosaic-orientation` | window→global | `left` | For `master-stack`: `left`, `right`, `top`, or `bottom` |
+| `@mosaic-mfact` | window→global | `50` | Master size as percent (window-scoped value wins) |
 | `@mosaic-step` | global | `5` | Default `resize-master` step |
 | `@mosaic-debug` | global | `0` | Set to `1` to log to `@mosaic-log-file` |
 | `@mosaic-log-file` | global | `${TMPDIR:-/tmp}/tmux-mosaic-$(uid).log` | Log path when debug on |
@@ -139,8 +140,9 @@ The dispatcher (`scripts/ops.sh`) sources the file selected by
 ### master-stack
 
 Faithful to Hyprland's master layout with `nmaster=1`, `new_status=slave`,
-`new_on_top=false`. Implemented atop tmux's native `main-vertical` +
-`main-pane-width <pct>%` + `swap-pane -D/-U`. The `swap-pane -D/-U` ring
+`new_on_top=false`. Implemented atop tmux's native `main-vertical`,
+`main-horizontal`, and mirrored variants, plus `main-pane-width <pct>%` /
+`main-pane-height <pct>%` + `swap-pane -D/-U`. The `swap-pane -D/-U` ring
 matches `MasterAlgorithm::getNextTarget` — same-category neighbor first,
 falls back across the master/stack boundary at the ring edges.
 
@@ -164,13 +166,9 @@ acting. Unset windows are inert.
 
 ## Known Limitations
 
-- **Single master.** Tmux's `main-vertical` is hardcoded to one master pane.
-  Multi-master would require hand-rolled layout strings; intentionally out of
-  scope for v0.x.
-
-- **Single orientation (left-master).** Top/right/bottom orientations are
-  achievable with `main-horizontal` and `*-mirrored` variants but require
-  per-orientation algorithm files. Not yet shipped.
+- **Single master.** Tmux's native `main-*` layouts are hardcoded to one
+  master pane. Multi-master would require hand-rolled layout strings;
+  intentionally out of scope for v0.x.
 
 - **No per-pane height factors.** Hyprland's `percSize` lets you bias one
   slave taller than the others. Tmux can express this via custom layout
@@ -180,7 +178,7 @@ acting. Unset windows are inert.
 - **Hooks fire only on tmux's structural events.** mosaic intercepts
   `after-split-window`, `after-kill-pane`, `pane-exited`, `pane-died`, and
   `after-resize-pane`. Operations that bypass these (e.g. direct
-  `select-layout` to a non-master-vertical layout, or `move-pane`
+  `select-layout` to a non-`main-*` layout, or `move-pane`
   reordering) won't trigger relayout. Run `relayout` explicitly if needed.
 
 # Acknowledgements

--- a/scripts/algorithms/master-stack.sh
+++ b/scripts/algorithms/master-stack.sh
@@ -4,6 +4,42 @@ algo_pane_count() { tmux display-message -p '#{window_panes}'; }
 algo_pane_index() { tmux display-message -p '#{pane_index}'; }
 algo_pane_base() { tmux display-message -p '#{e|+|:0,#{?pane-base-index,#{pane-base-index},0}}'; }
 
+algo_orientation_for() {
+  local win="$1" val
+  val=$(mosaic_get_w "@mosaic-orientation" "left" "$win")
+  case "$val" in
+  left | right | top | bottom)
+    echo "$val"
+    ;;
+  *)
+    mosaic_log "orientation: invalid=$val win=$win defaulting=left"
+    echo "left"
+    ;;
+  esac
+}
+
+algo_layout_for() {
+  case "$1" in
+  left) echo "main-vertical" ;;
+  right) echo "main-vertical-mirrored" ;;
+  top) echo "main-horizontal" ;;
+  bottom) echo "main-horizontal-mirrored" ;;
+  esac
+}
+
+algo_main_option_for() {
+  case "$1" in
+  left | right) echo "main-pane-width" ;;
+  top | bottom) echo "main-pane-height" ;;
+  esac
+}
+
+algo_apply_layout() {
+  local win="$1" orientation="$2" mfact="$3"
+  tmux set-window-option -t "$win" "$(algo_main_option_for "$orientation")" "${mfact}%" 2>/dev/null || true
+  tmux select-layout -t "$win" "$(algo_layout_for "$orientation")" 2>/dev/null || true
+}
+
 algo_mfact_for() {
   local win="$1"
   local val
@@ -35,13 +71,13 @@ algo_relayout() {
   n=$(tmux list-panes -t "$win" 2>/dev/null | wc -l)
   [[ "$n" -le 1 ]] && return 0
 
-  local mfact
+  local mfact orientation
   mfact=$(algo_mfact_for "$win")
+  orientation=$(algo_orientation_for "$win")
 
-  tmux set-window-option -t "$win" main-pane-width "${mfact}%" 2>/dev/null || true
-  tmux select-layout -t "$win" main-vertical 2>/dev/null || true
+  algo_apply_layout "$win" "$orientation" "$mfact"
 
-  mosaic_log "relayout: win=$win n=$n mfact=$mfact"
+  mosaic_log "relayout: win=$win n=$n orientation=$orientation mfact=$mfact"
 }
 
 algo_toggle() {
@@ -97,17 +133,26 @@ algo_sync_state() {
   n=$(tmux list-panes -t "$win" 2>/dev/null | wc -l)
   [[ "$n" -le 1 ]] && return 0
 
-  local pbase pane_w window_w pct
+  local pbase pane_size window_size pct orientation
+  orientation=$(algo_orientation_for "$win")
   pbase=$(algo_pane_base)
-  pane_w=$(tmux display-message -p -t "$win.$pbase" '#{pane_width}' 2>/dev/null)
-  window_w=$(tmux display-message -p -t "$win" '#{window_width}' 2>/dev/null)
-  [[ -z "$pane_w" ]] && return 0
-  [[ -z "$window_w" || "$window_w" -le 0 ]] && return 0
+  case "$orientation" in
+  left | right)
+    pane_size=$(tmux display-message -p -t "$win.$pbase" '#{pane_width}' 2>/dev/null)
+    window_size=$(tmux display-message -p -t "$win" '#{window_width}' 2>/dev/null)
+    ;;
+  top | bottom)
+    pane_size=$(tmux display-message -p -t "$win.$pbase" '#{pane_height}' 2>/dev/null)
+    window_size=$(tmux display-message -p -t "$win" '#{window_height}' 2>/dev/null)
+    ;;
+  esac
+  [[ -z "$pane_size" ]] && return 0
+  [[ -z "$window_size" || "$window_size" -le 0 ]] && return 0
 
-  pct=$((pane_w * 100 / window_w))
+  pct=$((pane_size * 100 / window_size))
   [[ "$pct" -lt 5 ]] && pct=5
   [[ "$pct" -gt 95 ]] && pct=95
 
   tmux set-option -wq -t "$win" "@mosaic-mfact" "$pct"
-  mosaic_log "sync-state: win=$win pane_w=$pane_w window_w=$window_w pct=$pct"
+  mosaic_log "sync-state: win=$win orientation=$orientation pane_size=$pane_size window_size=$window_size pct=$pct"
 }

--- a/scripts/defaults.sh
+++ b/scripts/defaults.sh
@@ -2,6 +2,7 @@
 
 mosaic_set_defaults() {
   tmux set-option -gq "@mosaic-default-algorithm" "master-stack"
+  tmux set-option -gwq "@mosaic-orientation" "left"
   tmux set-option -gq "@mosaic-mfact" "50"
   tmux set-option -gq "@mosaic-step" "5"
   tmux set-option -gq "@mosaic-debug" "0"

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -1,14 +1,18 @@
 #!/usr/bin/env bash
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-SOCKET="${MOSAIC_TEST_SOCKET:-mosaic-test}"
 
-mosaic_t() { tmux -L "$SOCKET" "$@"; }
+mosaic_socket() {
+  echo "${MOSAIC_TEST_SOCKET:-mosaic-test}-${BATS_TEST_NUMBER:-0}"
+}
+
+mosaic_t() { tmux -L "$(mosaic_socket)" "$@"; }
 
 mosaic_setup_server() {
   mosaic_t kill-server 2>/dev/null || true
   rm -f /tmp/tmux-mosaic-test.log
-  local conf="${BATS_TEST_TMPDIR:-/tmp}/mosaic-test.conf"
+  local conf
+  conf="${BATS_TEST_TMPDIR:-/tmp}/$(mosaic_socket).conf"
   cat >"$conf" <<EOF
 set -g base-index 1
 set -g pane-base-index 1
@@ -36,7 +40,7 @@ mosaic_split() {
 }
 
 mosaic_socket_path() {
-  echo "${TMUX_TMPDIR:-/tmp}/tmux-$(id -u)/$SOCKET"
+  echo "${TMUX_TMPDIR:-/tmp}/tmux-$(id -u)/$(mosaic_socket)"
 }
 
 mosaic_exec_direct() {

--- a/tests/integration/master_stack.bats
+++ b/tests/integration/master_stack.bats
@@ -11,6 +11,49 @@ teardown() {
   mosaic_teardown_server
 }
 
+set_orientation() {
+  mosaic_t set-option -wq -t "${1:-t:1}" "@mosaic-orientation" "${2:?orientation required}"
+}
+
+pane_field() {
+  mosaic_t list-panes -t "${1:-t:1}" -F '#{pane_index} #{pane_left} #{pane_top} #{pane_width} #{pane_height}' |
+    awk -v idx="${2:?pane index required}" -v field="${3:?field required}" '$1 == idx { print $field }'
+}
+
+layout_outer() {
+  mosaic_layout "${1:-t:1}" | awk 'match($0, /[\[{]/) { print substr($0, RSTART, 1) }'
+}
+
+assert_orientation_layout() {
+  local orient="${1:?orientation required}" outer
+  set_orientation t:1 "$orient"
+  for _ in 1 2 3; do mosaic_split; done
+  outer=$(layout_outer)
+
+  case "$orient" in
+  left)
+    [ "$outer" = "{" ]
+    [ "$(pane_field t:1 1 2)" = "0" ]
+    [ "$(pane_field t:1 1 5)" -gt "$(pane_field t:1 2 5)" ]
+    ;;
+  right)
+    [ "$outer" = "{" ]
+    [ "$(pane_field t:1 1 2)" -gt 0 ]
+    [ "$(pane_field t:1 1 5)" -gt "$(pane_field t:1 2 5)" ]
+    ;;
+  top)
+    [ "$outer" = "[" ]
+    [ "$(pane_field t:1 1 3)" = "0" ]
+    [ "$(pane_field t:1 1 4)" -gt "$(pane_field t:1 2 4)" ]
+    ;;
+  bottom)
+    [ "$outer" = "[" ]
+    [ "$(pane_field t:1 1 3)" -gt 0 ]
+    [ "$(pane_field t:1 1 4)" -gt "$(pane_field t:1 2 4)" ]
+    ;;
+  esac
+}
+
 @test "plugin load: defaults are set" {
   run mosaic_t show-option -gqv @mosaic-mfact
   [ "$status" -eq 0 ]
@@ -19,6 +62,10 @@ teardown() {
   run mosaic_t show-option -gqv @mosaic-default-algorithm
   [ "$status" -eq 0 ]
   [ "$output" = "master-stack" ]
+
+  run mosaic_t show-option -gwqv @mosaic-orientation
+  [ "$status" -eq 0 ]
+  [ "$output" = "left" ]
 }
 
 @test "plugin load: hooks are registered" {
@@ -41,6 +88,22 @@ teardown() {
   layout=$(mosaic_layout)
   [[ "$layout" == *"{"* ]]
   [[ "$layout" == *"["* ]] || [ "$(mosaic_pane_count)" = "2" ]
+}
+
+@test "orientation left keeps the master on the left" {
+  assert_orientation_layout left
+}
+
+@test "orientation right keeps the master on the right" {
+  assert_orientation_layout right
+}
+
+@test "orientation top keeps the master on the top" {
+  assert_orientation_layout top
+}
+
+@test "orientation bottom keeps the master on the bottom" {
+  assert_orientation_layout bottom
 }
 
 @test "5 panes: master + equal-split stack" {
@@ -90,6 +153,17 @@ teardown() {
 
   mosaic_op resize-master +200
   [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "95" ]
+}
+
+@test "resize-master in top orientation writes main-pane-height" {
+  for _ in 1 2 3; do mosaic_split; done
+  set_orientation t:1 top
+  mosaic_op relayout
+
+  mosaic_op resize-master +10
+
+  [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
+  [ "$(mosaic_t show-option -wqv -t t:1 main-pane-height)" = "60%" ]
 }
 
 @test "resize-master on two windows is independent" {
@@ -183,4 +257,20 @@ teardown() {
   mosaic_t resize-pane -Z
   sleep 0.2
   [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
+}
+
+@test "drag-resize in top orientation syncs mfact from height" {
+  set_orientation t:1 top
+  mosaic_split
+  mosaic_t resize-pane -t t:1.1 -y 30
+  sleep 0.2
+
+  mfact=$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)
+  [ "$mfact" -ge 55 ]
+  [ "$mfact" -le 65 ]
+
+  mosaic_split
+  pane_h=$(mosaic_t list-panes -t t:1 -F '#{pane_index} #{pane_height}' | awk '$1==1 { print $2 }')
+  [ "$pane_h" -ge 28 ]
+  [ "$pane_h" -le 31 ]
 }


### PR DESCRIPTION
Why: Master-stack was hard-coded to left-only placement, which left the other native tmux orientations unavailable.

How: Add a window-scoped `@mosaic-orientation` that maps master-stack onto tmux's native `main-*` layouts, update relayout and state sync to use width or height as needed, and extend integration coverage for all four orientations.

Closes #5