### PR TITLE
feat(algorithm): add even-horizontal

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,11 @@ falls back across the master/stack boundary at the ring edges.
 Equal-height panes in a column via tmux's native `even-vertical` layout. Set
 `@mosaic-algorithm` to `even-vertical` on a window to use it.
 
+### even-horizontal
+
+Equal-width panes in a row via tmux's native `even-horizontal` layout. Set
+`@mosaic-algorithm` to `even-horizontal` on a window to use it.
+
 ## FAQ
 
 **Q: Why doesn't `promote` toggle when I'm already master?**

--- a/scripts/algorithms/even-horizontal.sh
+++ b/scripts/algorithms/even-horizontal.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+algo_relayout() {
+  local win="${1:-}"
+  [[ -z "$win" ]] && win=$(tmux display-message -p '#{window_id}')
+
+  if ! mosaic_enabled "$win"; then
+    mosaic_log "relayout: disabled on $win, skipping"
+    return 0
+  fi
+
+  local n
+  n=$(tmux list-panes -t "$win" 2>/dev/null | wc -l)
+  [[ "$n" -le 1 ]] && return 0
+
+  tmux select-layout -t "$win" even-horizontal 2>/dev/null || true
+
+  mosaic_log "relayout: win=$win n=$n"
+}
+
+algo_toggle() {
+  local win
+  win=$(tmux display-message -p '#{window_id}')
+  if mosaic_enabled "$win"; then
+    tmux set-option -wqu -t "$win" "@mosaic-enabled" 2>/dev/null
+    tmux display-message "mosaic: off"
+  else
+    tmux set-option -wq -t "$win" "@mosaic-enabled" 1
+    tmux display-message "mosaic: on"
+    algo_relayout "$win"
+  fi
+}

--- a/tests/integration/even_horizontal.bats
+++ b/tests/integration/even_horizontal.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+
+load '../helpers.bash'
+
+setup() {
+  mosaic_setup_server
+  mosaic_t set-option -wq -t t:1 "@mosaic-algorithm" "even-horizontal"
+  mosaic_enable
+}
+
+teardown() {
+  mosaic_teardown_server
+}
+
+@test "even-horizontal: 4 panes are arranged in an equal-width row" {
+  for _ in 1 2 3; do mosaic_split; done
+  [ "$(mosaic_pane_count)" = "4" ]
+
+  layout=$(mosaic_layout)
+  [[ "$layout" == *"{"* ]]
+  [[ "$layout" != *"["* ]]
+
+  widths=$(mosaic_t list-panes -t t:1 -F '#{pane_width}' | sort -n)
+  min=$(printf '%s\n' "$widths" | head -n1)
+  max=$(printf '%s\n' "$widths" | tail -n1)
+
+  [ $((max - min)) -le 1 ]
+}


### PR DESCRIPTION
This adds an `even-horizontal` algorithm backed by tmux's native `even-horizontal` layout and documents it in the README. Since tmux's native layout arranges panes as an equal-width row, the new integration test asserts that behavior directly.

The issue text describes equal heights in a column, but tmux's native `even-horizontal` layout does the opposite. This keeps the implementation tmux-native and tests the actual layout geometry instead of papering over the naming mismatch.

Verified locally with `just ci` and `just build` in the `.#ci` shell.

Closes #9.
