### PR TITLE
feat(algorithm): add monocle

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,12 @@ falls back across the master/stack boundary at the ring edges.
 Equal-height panes in a column via tmux's native `even-vertical` layout. Set
 `@mosaic-algorithm` to `even-vertical` on a window to use it.
 
+### monocle
+
+Fullscreen active pane via tmux's native zoom. Set `@mosaic-algorithm` to
+`monocle` on a window to keep the active pane zoomed as focus changes, panes
+split, and panes exit.
+
 ## FAQ
 
 **Q: Why doesn't `promote` toggle when I'm already master?**

--- a/scripts/algorithms/monocle.sh
+++ b/scripts/algorithms/monocle.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+algo_relayout() {
+  local win="${1:-}"
+  [[ -z "$win" ]] && win=$(tmux display-message -p '#{window_id}')
+
+  if ! mosaic_enabled "$win"; then
+    mosaic_log "relayout: disabled on $win, skipping"
+    return 0
+  fi
+
+  local n zoomed
+  n=$(tmux list-panes -t "$win" 2>/dev/null | wc -l)
+  [[ "$n" -le 1 ]] && return 0
+
+  zoomed=$(tmux display-message -p -t "$win" '#{window_zoomed_flag}')
+  if [[ "$zoomed" != "1" ]]; then
+    tmux resize-pane -Z -t "$win" 2>/dev/null || true
+  fi
+
+  mosaic_log "relayout: win=$win n=$n zoomed=$zoomed"
+}
+
+algo_toggle() {
+  local win
+  win=$(tmux display-message -p '#{window_id}')
+  if mosaic_enabled "$win"; then
+    tmux set-option -wqu -t "$win" "@mosaic-enabled" 2>/dev/null
+    tmux display-message "mosaic: off"
+  else
+    tmux set-option -wq -t "$win" "@mosaic-enabled" 1
+    tmux display-message "mosaic: on"
+    algo_relayout "$win"
+  fi
+}

--- a/scripts/defaults.sh
+++ b/scripts/defaults.sh
@@ -23,4 +23,6 @@ mosaic_register_hooks() {
     "run-shell -b '$exec relayout #{window_id}'"
   tmux set-hook -ga after-resize-pane \
     "run-shell -b '$exec _sync-state #{window_id}'"
+  tmux set-hook -ga after-select-pane \
+    "run-shell -b '$exec relayout #{window_id}'"
 }

--- a/tests/integration/monocle.bats
+++ b/tests/integration/monocle.bats
@@ -1,0 +1,62 @@
+#!/usr/bin/env bats
+
+load '../helpers.bash'
+
+setup() {
+  mosaic_setup_server
+  mosaic_t set-option -wq -t t:1 "@mosaic-algorithm" "monocle"
+}
+
+teardown() {
+  mosaic_teardown_server
+}
+
+window_zoomed() {
+  mosaic_t display-message -p -t "${1:-t:1}" '#{window_zoomed_flag}'
+}
+
+active_pane_id() {
+  mosaic_t display-message -p -t "${1:-t:1}" '#{pane_id}'
+}
+
+@test "monocle: toggle on zooms the focused pane" {
+  for _ in 1 2; do mosaic_split; done
+  mosaic_t select-pane -t t:1.2
+  pid=$(active_pane_id)
+
+  [ "$(window_zoomed)" = "0" ]
+
+  mosaic_op toggle
+  sleep 0.2
+
+  [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-enabled)" = "1" ]
+  [ "$(window_zoomed)" = "1" ]
+  [ "$(active_pane_id)" = "$pid" ]
+}
+
+@test "monocle: split keeps the new pane zoomed" {
+  mosaic_op toggle
+  sleep 0.2
+
+  mosaic_split
+
+  [ "$(mosaic_pane_count)" = "2" ]
+  [ "$(window_zoomed)" = "1" ]
+  [ "$(mosaic_pane_index)" = "2" ]
+}
+
+@test "monocle: selecting the next pane re-zooms the new active pane" {
+  for _ in 1 2; do mosaic_split; done
+
+  mosaic_op toggle
+  sleep 0.2
+
+  before=$(active_pane_id)
+
+  mosaic_t select-pane -t :.+
+  sleep 0.2
+
+  after=$(active_pane_id)
+  [ "$after" != "$before" ]
+  [ "$(window_zoomed)" = "1" ]
+}


### PR DESCRIPTION
Why: The v0.1.0 algorithm set still needed a tmux-native fullscreen layout that tracks the active pane.

How: Add a monocle algorithm that re-zooms the active pane when the window is enabled, and hook `after-select-pane` so focus changes, splits, and other structural events keep the active pane fullscreen. Add integration coverage for toggle, split, and focus cycling.

Closes #7