### PR TITLE
refactor: share common algorithm helpers

### DIFF
--- a/scripts/algorithms/even-horizontal.sh
+++ b/scripts/algorithms/even-horizontal.sh
@@ -1,32 +1,5 @@
 #!/usr/bin/env bash
 
-algo_relayout() {
-  local win="${1:-}"
-  [[ -z "$win" ]] && win=$(tmux display-message -p '#{window_id}')
+algo_relayout() { mosaic_relayout_simple even-horizontal "${1:-}"; }
 
-  if ! mosaic_enabled "$win"; then
-    mosaic_log "relayout: disabled on $win, skipping"
-    return 0
-  fi
-
-  local n
-  n=$(tmux list-panes -t "$win" 2>/dev/null | wc -l)
-  [[ "$n" -le 1 ]] && return 0
-
-  tmux select-layout -t "$win" even-horizontal 2>/dev/null || true
-
-  mosaic_log "relayout: win=$win n=$n"
-}
-
-algo_toggle() {
-  local win
-  win=$(tmux display-message -p '#{window_id}')
-  if mosaic_enabled "$win"; then
-    tmux set-option -wqu -t "$win" "@mosaic-enabled" 2>/dev/null
-    tmux display-message "mosaic: off"
-  else
-    tmux set-option -wq -t "$win" "@mosaic-enabled" 1
-    tmux display-message "mosaic: on"
-    algo_relayout "$win"
-  fi
-}
+algo_toggle() { mosaic_toggle_window algo_relayout; }

--- a/scripts/algorithms/even-vertical.sh
+++ b/scripts/algorithms/even-vertical.sh
@@ -1,32 +1,5 @@
 #!/usr/bin/env bash
 
-algo_relayout() {
-  local win="${1:-}"
-  [[ -z "$win" ]] && win=$(tmux display-message -p '#{window_id}')
+algo_relayout() { mosaic_relayout_simple even-vertical "${1:-}"; }
 
-  if ! mosaic_enabled "$win"; then
-    mosaic_log "relayout: disabled on $win, skipping"
-    return 0
-  fi
-
-  local n
-  n=$(tmux list-panes -t "$win" 2>/dev/null | wc -l)
-  [[ "$n" -le 1 ]] && return 0
-
-  tmux select-layout -t "$win" even-vertical 2>/dev/null || true
-
-  mosaic_log "relayout: win=$win n=$n"
-}
-
-algo_toggle() {
-  local win
-  win=$(tmux display-message -p '#{window_id}')
-  if mosaic_enabled "$win"; then
-    tmux set-option -wqu -t "$win" "@mosaic-enabled" 2>/dev/null
-    tmux display-message "mosaic: off"
-  else
-    tmux set-option -wq -t "$win" "@mosaic-enabled" 1
-    tmux display-message "mosaic: on"
-    algo_relayout "$win"
-  fi
-}
+algo_toggle() { mosaic_toggle_window algo_relayout; }

--- a/scripts/algorithms/master-stack.sh
+++ b/scripts/algorithms/master-stack.sh
@@ -59,19 +59,10 @@ algo_swap_keep_focus() {
 }
 
 algo_relayout() {
-  local win="${1:-}"
-  [[ -z "$win" ]] && win=$(tmux display-message -p '#{window_id}')
-
-  if ! mosaic_enabled "$win"; then
-    mosaic_log "relayout: disabled on $win, skipping"
-    return 0
-  fi
-
-  local n
-  n=$(tmux list-panes -t "$win" 2>/dev/null | wc -l)
-  [[ "$n" -le 1 ]] && return 0
-
-  local mfact orientation
+  local win n mfact orientation
+  win=$(mosaic_resolve_window "${1:-}")
+  n=$(mosaic_window_pane_count "$win")
+  mosaic_can_relayout_window "$win" "$n" || return 0
   mfact=$(algo_mfact_for "$win")
   orientation=$(algo_orientation_for "$win")
 
@@ -80,18 +71,7 @@ algo_relayout() {
   mosaic_log "relayout: win=$win n=$n orientation=$orientation mfact=$mfact"
 }
 
-algo_toggle() {
-  local win
-  win=$(tmux display-message -p '#{window_id}')
-  if mosaic_enabled "$win"; then
-    tmux set-option -wqu -t "$win" "@mosaic-enabled" 2>/dev/null
-    tmux display-message "mosaic: off"
-  else
-    tmux set-option -wq -t "$win" "@mosaic-enabled" 1
-    tmux display-message "mosaic: on"
-    algo_relayout "$win"
-  fi
-}
+algo_toggle() { mosaic_toggle_window algo_relayout; }
 
 algo_promote() {
   local idx n pbase
@@ -115,7 +95,7 @@ algo_resize_master() {
     delta=$(mosaic_get "@mosaic-step" "5")
   fi
   local win cur new
-  win=$(tmux display-message -p '#{window_id}')
+  win=$(mosaic_current_window)
   cur=$(algo_mfact_for "$win")
   new=$((cur + delta))
   [[ "$new" -lt 5 ]] && new=5
@@ -127,10 +107,10 @@ algo_resize_master() {
 algo_sync_state() {
   local win="$1"
   mosaic_enabled "$win" || return 0
-  [[ "$(tmux display-message -p -t "$win" '#{window_zoomed_flag}')" == "1" ]] && return 0
+  [[ "$(mosaic_window_zoomed "$win")" == "1" ]] && return 0
 
   local n
-  n=$(tmux list-panes -t "$win" 2>/dev/null | wc -l)
+  n=$(mosaic_window_pane_count "$win")
   [[ "$n" -le 1 ]] && return 0
 
   local pbase pane_size window_size pct orientation

--- a/scripts/algorithms/monocle.sh
+++ b/scripts/algorithms/monocle.sh
@@ -1,19 +1,11 @@
 #!/usr/bin/env bash
 
 algo_relayout() {
-  local win="${1:-}"
-  [[ -z "$win" ]] && win=$(tmux display-message -p '#{window_id}')
-
-  if ! mosaic_enabled "$win"; then
-    mosaic_log "relayout: disabled on $win, skipping"
-    return 0
-  fi
-
-  local n zoomed
-  n=$(tmux list-panes -t "$win" 2>/dev/null | wc -l)
-  [[ "$n" -le 1 ]] && return 0
-
-  zoomed=$(tmux display-message -p -t "$win" '#{window_zoomed_flag}')
+  local win n zoomed
+  win=$(mosaic_resolve_window "${1:-}")
+  n=$(mosaic_window_pane_count "$win")
+  mosaic_can_relayout_window "$win" "$n" || return 0
+  zoomed=$(mosaic_window_zoomed "$win")
   if [[ "$zoomed" != "1" ]]; then
     tmux resize-pane -Z -t "$win" 2>/dev/null || true
   fi
@@ -21,15 +13,4 @@ algo_relayout() {
   mosaic_log "relayout: win=$win n=$n zoomed=$zoomed"
 }
 
-algo_toggle() {
-  local win
-  win=$(tmux display-message -p '#{window_id}')
-  if mosaic_enabled "$win"; then
-    tmux set-option -wqu -t "$win" "@mosaic-enabled" 2>/dev/null
-    tmux display-message "mosaic: off"
-  else
-    tmux set-option -wq -t "$win" "@mosaic-enabled" 1
-    tmux display-message "mosaic: on"
-    algo_relayout "$win"
-  fi
-}
+algo_toggle() { mosaic_toggle_window algo_relayout; }

--- a/scripts/defaults.sh
+++ b/scripts/defaults.sh
@@ -9,20 +9,13 @@ mosaic_set_defaults() {
 }
 
 mosaic_register_hooks() {
-  local exec
+  local exec hook
   exec=$(tmux show-option -gqv "@mosaic-exec")
   [[ -z "$exec" ]] && return 0
 
-  tmux set-hook -ga after-split-window \
-    "run-shell -b '$exec relayout #{window_id}'"
-  tmux set-hook -ga after-kill-pane \
-    "run-shell -b '$exec relayout #{window_id}'"
-  tmux set-hook -ga pane-exited \
-    "run-shell -b '$exec relayout #{window_id}'"
-  tmux set-hook -ga pane-died \
-    "run-shell -b '$exec relayout #{window_id}'"
+  for hook in after-split-window after-kill-pane pane-exited pane-died after-select-pane; do
+    tmux set-hook -ga "$hook" "run-shell -b '$exec relayout #{window_id}'"
+  done
   tmux set-hook -ga after-resize-pane \
     "run-shell -b '$exec _sync-state #{window_id}'"
-  tmux set-hook -ga after-select-pane \
-    "run-shell -b '$exec relayout #{window_id}'"
 }

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -4,11 +4,7 @@ mosaic_get() {
   local opt="$1" default="$2"
   local val
   val=$(tmux show-option -gqv "$opt" 2>/dev/null)
-  if [[ -z "$val" ]]; then
-    echo "$default"
-  else
-    echo "$val"
-  fi
+  printf '%s\n' "${val:-$default}"
 }
 
 mosaic_get_w() {
@@ -19,11 +15,7 @@ mosaic_get_w() {
   else
     val=$(tmux show-option -wqv "$opt" 2>/dev/null)
   fi
-  if [[ -z "$val" ]]; then
-    echo "$default"
-  else
-    echo "$val"
-  fi
+  printf '%s\n' "${val:-$default}"
 }
 
 mosaic_enabled() {
@@ -31,6 +23,52 @@ mosaic_enabled() {
   local val
   val=$(mosaic_get_w "@mosaic-enabled" "0" "$target")
   [[ "$val" == "1" ]] || [[ "$val" == "on" ]] || [[ "$val" == "true" ]]
+}
+
+mosaic_current_window() { tmux display-message -p '#{window_id}'; }
+
+mosaic_resolve_window() {
+  local win="${1:-$(mosaic_current_window)}"
+  printf '%s\n' "$win"
+}
+
+mosaic_window_pane_count() {
+  tmux display-message -p -t "$(mosaic_resolve_window "${1:-}")" '#{window_panes}'
+}
+
+mosaic_window_zoomed() {
+  tmux display-message -p -t "$(mosaic_resolve_window "${1:-}")" '#{window_zoomed_flag}'
+}
+
+mosaic_can_relayout_window() {
+  local win="$1" n="$2"
+  if ! mosaic_enabled "$win"; then
+    mosaic_log "relayout: disabled on $win, skipping"
+    return 1
+  fi
+  [[ "$n" -gt 1 ]]
+}
+
+mosaic_toggle_window() {
+  local relayout_fn="$1" win
+  win=$(mosaic_current_window)
+  if mosaic_enabled "$win"; then
+    tmux set-option -wqu -t "$win" "@mosaic-enabled" 2>/dev/null
+    tmux display-message "mosaic: off"
+  else
+    tmux set-option -wq -t "$win" "@mosaic-enabled" 1
+    tmux display-message "mosaic: on"
+    "$relayout_fn" "$win"
+  fi
+}
+
+mosaic_relayout_simple() {
+  local layout="$1" win n
+  win=$(mosaic_resolve_window "${2:-}")
+  n=$(mosaic_window_pane_count "$win")
+  mosaic_can_relayout_window "$win" "$n" || return 0
+  tmux select-layout -t "$win" "$layout" 2>/dev/null || true
+  mosaic_log "relayout: win=$win n=$n layout=$layout"
 }
 
 mosaic_log() {

--- a/scripts/ops.sh
+++ b/scripts/ops.sh
@@ -4,16 +4,11 @@ CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=helpers.sh
 source "$CURRENT_DIR/helpers.sh"
 
-current_window() { tmux display-message -p '#{window_id}'; }
-
 algorithm_for_window() {
   local win="$1"
-  local algo
-  algo=$(mosaic_get_w "@mosaic-algorithm" "" "$win")
-  if [[ -z "$algo" ]]; then
-    algo=$(mosaic_get "@mosaic-default-algorithm" "master-stack")
-  fi
-  echo "$algo"
+  local fallback
+  fallback=$(mosaic_get "@mosaic-default-algorithm" "master-stack")
+  mosaic_get_w "@mosaic-algorithm" "$fallback" "$win"
 }
 
 load_algorithm() {
@@ -33,7 +28,7 @@ load_algorithm() {
 }
 
 cmd="${1:-}"
-shift || true
+[[ $# -gt 0 ]] && shift
 
 WIN_ARG=""
 case "$cmd" in
@@ -42,7 +37,7 @@ relayout | _sync-state)
   ;;
 esac
 
-target_window="${WIN_ARG:-$(current_window)}"
+target_window=$(mosaic_resolve_window "$WIN_ARG")
 algo=$(algorithm_for_window "$target_window")
 
 if ! load_algorithm "$algo"; then


### PR DESCRIPTION
## Problem

The shell code had grown copy-paste branches for the same work: every algorithm reimplemented current-window lookup, disabled and single-pane relayout guards, and the same toggle path, while hook registration repeated the same `relayout` command five times. The relayout guards also paid for `list-panes | wc -l` even though tmux already exposes `#{window_panes}` directly.

## Solution

Add shared helpers for current-window resolution, pane counts, zoom state, common toggle handling, and simple-layout relayouts, then switch `master-stack`, `even-horizontal`, `even-vertical`, `monocle`, the dispatcher, and hook registration over to them. This deletes more shell than it adds, keeps the algorithm files focused on layout-specific behavior, and replaces the `list-panes | wc -l` pipeline with tmux's native format queries. Verified locally with `direnv exec /home/barrett/dev/tmux-mosaic just --justfile /tmp/tmux-mosaic/bash-helpers/justfile --working-directory /tmp/tmux-mosaic/bash-helpers ci` and the matching `build` recipe.
