### PR TITLE
feat(algorithm): add grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,11 @@ split, and panes exit.
 Equal-width panes in a row via tmux's native `even-horizontal` layout. Set
 `@mosaic-algorithm` to `even-horizontal` on a window to use it.
 
+### grid
+
+Equal-size panes in a grid via tmux's native `tiled` layout. Set
+`@mosaic-algorithm` to `grid` on a window to use it.
+
 ## FAQ
 
 **Q: Why doesn't `promote` toggle when I'm already master?**

--- a/scripts/algorithms/grid.sh
+++ b/scripts/algorithms/grid.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+algo_relayout() { mosaic_relayout_simple tiled "${1:-}"; }
+
+algo_toggle() { mosaic_toggle_window algo_relayout; }

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -40,6 +40,21 @@ mosaic_window_zoomed() {
   tmux display-message -p -t "$(mosaic_resolve_window "${1:-}")" '#{window_zoomed_flag}'
 }
 
+mosaic_first_client() {
+  tmux list-clients -F '#{client_name}' 2>/dev/null | head -n1
+}
+
+mosaic_show_message() {
+  local message="$*" client
+  client=$(tmux display-message -p '#{client_name}' 2>/dev/null)
+  [[ -z "$client" ]] && client=$(mosaic_first_client)
+  if [[ -n "$client" ]]; then
+    tmux display-message -c "$client" "$message"
+  else
+    printf '%s\n' "$message" >&2
+  fi
+}
+
 mosaic_can_relayout_window() {
   local win="$1" n="$2"
   if ! mosaic_enabled "$win"; then
@@ -54,10 +69,10 @@ mosaic_toggle_window() {
   win=$(mosaic_current_window)
   if mosaic_enabled "$win"; then
     tmux set-option -wqu -t "$win" "@mosaic-enabled" 2>/dev/null
-    tmux display-message "mosaic: off"
+    mosaic_show_message "mosaic: off"
   else
     tmux set-option -wq -t "$win" "@mosaic-enabled" 1
-    tmux display-message "mosaic: on"
+    mosaic_show_message "mosaic: on"
     "$relayout_fn" "$win"
   fi
 }

--- a/scripts/ops.sh
+++ b/scripts/ops.sh
@@ -45,12 +45,13 @@ if ! load_algorithm "$algo"; then
 fi
 
 dispatch_optional() {
-  local fn="$1"
+  local fn="$1" message
   shift
   if declare -f "$fn" >/dev/null; then
     "$fn" "$@"
   else
-    tmux display-message "mosaic: $algo does not implement ${fn#algo_}"
+    message="mosaic: $algo does not implement ${fn#algo_}"
+    mosaic_show_message "$message"
   fi
 }
 

--- a/tests/integration/grid.bats
+++ b/tests/integration/grid.bats
@@ -1,0 +1,38 @@
+#!/usr/bin/env bats
+
+load '../helpers.bash'
+
+setup() {
+  mosaic_setup_server
+  mosaic_t set-option -wq -t t:1 "@mosaic-algorithm" "grid"
+  mosaic_enable
+}
+
+teardown() {
+  mosaic_teardown_server
+}
+
+@test "grid: 4 panes use tiled layout" {
+  for _ in 1 2 3; do mosaic_split; done
+  [ "$(mosaic_pane_count)" = "4" ]
+
+  layout=$(mosaic_layout)
+  [[ "$layout" == *"["* ]]
+  [[ "$layout" == *"{"* ]]
+
+  lefts=$(mosaic_t list-panes -t t:1 -F '#{pane_left}' | sort -un)
+  tops=$(mosaic_t list-panes -t t:1 -F '#{pane_top}' | sort -un)
+  widths=$(mosaic_t list-panes -t t:1 -F '#{pane_width}' | sort -n)
+  heights=$(mosaic_t list-panes -t t:1 -F '#{pane_height}' | sort -n)
+
+  [ "$(printf '%s\n' "$lefts" | wc -l)" = "2" ]
+  [ "$(printf '%s\n' "$tops" | wc -l)" = "2" ]
+  [ $(($(printf '%s\n' "$widths" | tail -n1) - $(printf '%s\n' "$widths" | head -n1))) -le 1 ]
+  [ $(($(printf '%s\n' "$heights" | tail -n1) - $(printf '%s\n' "$heights" | head -n1))) -le 1 ]
+}
+
+@test "grid: promote surfaces the missing operation message in direct cli use" {
+  run mosaic_exec_direct promote
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"mosaic: grid does not implement promote"* ]]
+}


### PR DESCRIPTION
## Problem

`grid` was still missing, even though the shared helper refactor now on `main` made it straightforward to add without copying the old toggle and relayout boilerplate. Direct CLI use of unsupported operations on no-master layouts also had no visible message path when no tmux client was attached.

## Solution

Add `scripts/algorithms/grid.sh` on top of the shared helper layer using tmux's native `tiled` layout, document `grid` in the README, and add integration coverage for both the tiled 2x2 geometry and the missing-`promote` message. Route user-facing messages through a shared `mosaic_show_message` helper so they still surface in direct CLI use when there is no attached client.

Verified locally with `direnv exec /home/barrett/dev/tmux-mosaic just --justfile /tmp/tmux-mosaic/6-clean/justfile --working-directory /tmp/tmux-mosaic/6-clean ci` and the matching `build` recipe.

Closes #6.
