### PR TITLE
docs: split the README from install and algorithm docs

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,0 +1,70 @@
+# Installation
+
+`tmux-mosaic` supports TPM, manual, and nix installs. It requires tmux 3.2+.
+
+Mosaic installs no default keybindings. It sets `@mosaic-exec` so your own
+bindings work across install methods.
+
+## TPM
+
+Add mosaic to your tmux config:
+
+```tmux
+set -g @plugin 'barrettruth/tmux-mosaic'
+```
+
+Install plugins with `prefix + I` if you use TPM.
+
+## Manual
+
+Clone the repo somewhere tmux can reach it:
+
+```sh
+git clone https://github.com/barrettruth/tmux-mosaic ~/.config/tmux/plugins/tmux-mosaic
+```
+
+Source the plugin from your tmux config:
+
+```tmux
+run-shell ~/.config/tmux/plugins/tmux-mosaic/mosaic.tmux
+```
+
+## Nix
+
+Add the flake input:
+
+```nix
+inputs.tmux-mosaic.url = "github:barrettruth/tmux-mosaic";
+```
+
+Source the packaged plugin from your tmux wrapper config:
+
+```tmux
+run-shell ${tmux-mosaic.packages.${system}.default}/share/tmux-plugins/mosaic/mosaic.tmux
+```
+
+## After installing
+
+Reload tmux if it is already running:
+
+```sh
+tmux source-file ~/.tmux.conf
+```
+
+Enable mosaic on the current window:
+
+```tmux
+set-option -wq @mosaic-enabled 1
+```
+
+Optional example bindings:
+
+```tmux
+bind Enter run '#{E:@mosaic-exec} promote'
+bind -r , run '#{E:@mosaic-exec} resize-master -5'
+bind -r . run '#{E:@mosaic-exec} resize-master +5'
+bind T run '#{E:@mosaic-exec} toggle'
+```
+
+For focus movement, swapping, and zoom, keep using stock tmux commands. For the
+algorithm reference, see [docs/algorithms](docs/algorithms/README.md).

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 **Master/stack pane tiling for tmux**
 
-A focused tmux plugin that brings dynamic-WM tiling to panes — Hyprland's master
-layout, faithful to the source. Algorithm-pluggable, opt-in per window, no key
-grabs.
+A focused tmux plugin for master/stack pane tiling and a small set of adjacent
+layouts. Mosaic is opt-in per window, uses native tmux layouts where possible,
+and installs no default keybindings.
+
+Requires tmux 3.2+.
 
 ```
 ┌────────────┬────────────┐
@@ -16,200 +18,86 @@ grabs.
 └────────────┴────────────┘
 ```
 
-## Features
+## Quick start
 
-- Hyprland master-layout semantics (verified against `MasterAlgorithm.cpp`)
-- Per-window opt-in — disabled windows are entirely untouched
-- Strategy pattern under `scripts/algorithms/` for adding new layouts
-- Native tmux primitives only — no hand-rolled layout strings, no CRC-16
-
-## Requirements
-
-- tmux 3.2+ (uses `display-popup`-era hooks and `main-pane-width <pct>%`)
-
-## Installation
-
-### Nix (flake input)
-
-```nix
-inputs.tmux-mosaic.url = "github:barrettruth/tmux-mosaic";
-
-# In your tmux wrapper config:
-run-shell ${tmux-mosaic.packages.${system}.default}/share/tmux-plugins/mosaic/mosaic.tmux
-```
-
-### TPM
-
-```tmux
-set -g @plugin 'barrettruth/tmux-mosaic'
-```
-
-### Manual
-
-```sh
-git clone https://github.com/barrettruth/tmux-mosaic ~/.config/tmux/plugins/tmux-mosaic
-```
-
-```tmux
-run-shell ~/.config/tmux/plugins/tmux-mosaic/mosaic.tmux
-```
-
-## Use
-
-Mosaic is **opt-in per window**:
+1. Install mosaic with TPM, manually, or via nix. See
+   [INSTALLATION.md](INSTALLATION.md).
+2. Enable it on the current window:
 
 ```tmux
 set-option -wq @mosaic-enabled 1
 ```
 
-Stock tmux already covers the trivial ops (focus, swap, zoom). Mosaic adds only
-the operations tmux can't express on its own. The plugin exports `@mosaic-exec`
-so paths resolve cleanly across nix-store / TPM / manual installs:
+3. Add your own bindings if you want them. Mosaic exports `@mosaic-exec` so the
+   same bindings work across TPM, manual, and nix installs.
 
 ```tmux
-# Stock tmux primitives — work the way Hyprland's master layout does
-# because mosaic keeps the layout as main-vertical
-bind a select-pane -t :.+
-bind f select-pane -t :.-
-bind M select-pane -t :.1
-bind d swap-pane -D
-bind u swap-pane -U
-bind z resize-pane -Z
-
-# mosaic value-adds
 bind Enter run '#{E:@mosaic-exec} promote'
 bind -r , run '#{E:@mosaic-exec} resize-master -5'
 bind -r . run '#{E:@mosaic-exec} resize-master +5'
 bind T run '#{E:@mosaic-exec} toggle'
 ```
 
+Bindings shown here are examples only. Mosaic does not install any bindings by
+default.
+
+## Model
+
+- `master-stack` is the default algorithm.
+- `@mosaic-enabled` is window-scoped. Unset windows are untouched.
+- Stock tmux still handles focus movement, swapping, and zoom well.
+- Mosaic adds the few operations tmux does not already express cleanly.
+
 ## Operations
 
-mosaic exposes four operations. Everything else is stock tmux.
+| Op                 | Behavior                                                                                 |
+| ------------------ | ---------------------------------------------------------------------------------------- |
+| `toggle`           | Enable or disable tiling on the current window                                           |
+| `promote`          | Move the focused stack pane to master. On master: swap with stack-top                    |
+| `resize-master ±N` | Adjust master size by N percent, clamped to 5–95                                         |
+| `relayout`         | Force re-apply the current algorithm when you need to recover from manual layout changes |
 
-| Op                 | Behavior                                                                                               |
-| ------------------ | ------------------------------------------------------------------------------------------------------ |
-| `toggle`           | Enable/disable tiling on the current window                                                            |
-| `promote`          | Move focused stack pane to master. On master: swap with stack-top (Hyprland's `swapwithmaster auto`)   |
-| `resize-master ±N` | Adjust master size by N percent (clamped 5–95)                                                         |
-| `relayout`         | Force re-apply the current algorithm (rarely needed — hooks fire on splits, kills, exits, and resizes) |
+For focus, swapping through the ring, and zoom, use stock tmux directly:
 
-For the non-master-stack-specific ops, use stock tmux directly:
-
-| Want                                                                  | Tmux command                                              |
-| --------------------------------------------------------------------- | --------------------------------------------------------- |
-| Focus next/prev pane in the ring                                      | `select-pane -t :.+` / `:.-`                              |
-| Focus the master                                                      | `select-pane -t :.1` (or `:.0` if `pane-base-index` is 0) |
-| Swap focused pane through the ring (Hyprland `swapnext` / `swapprev`) | `swap-pane -D` / `-U`                                     |
-| Zoom focused pane (monocle equivalent)                                | `resize-pane -Z`                                          |
-
-These work because mosaic keeps the layout in tmux's `main-*` family, which
-positions panes by index and keeps pane 1 as the master. Tmux's index-order ops
-then traverse the master/stack ring exactly as Hyprland's master layout does.
+| Want                                    | Tmux command                                              |
+| --------------------------------------- | --------------------------------------------------------- |
+| Focus next or previous pane in the ring | `select-pane -t :.+` / `:.-`                              |
+| Focus the master                        | `select-pane -t :.1` (or `:.0` if `pane-base-index` is 0) |
+| Swap the focused pane through the ring  | `swap-pane -D` / `-U`                                     |
+| Zoom the focused pane                   | `resize-pane -Z`                                          |
 
 ## Options
 
-| Option                      | Scope         | Default                                  | Purpose                                                 |
-| --------------------------- | ------------- | ---------------------------------------- | ------------------------------------------------------- |
-| `@mosaic-enabled`           | window        | unset                                    | Set to `1` to tile this window                          |
-| `@mosaic-algorithm`         | window        | (uses default)                           | Per-window algorithm override                           |
-| `@mosaic-default-algorithm` | global        | `master-stack`                           | Default for windows without override                    |
-| `@mosaic-orientation`       | window→global | `left`                                   | For `master-stack`: `left`, `right`, `top`, or `bottom` |
-| `@mosaic-mfact`             | window→global | `50`                                     | Master size as percent (window-scoped value wins)       |
-| `@mosaic-step`              | global        | `5`                                      | Default `resize-master` step                            |
-| `@mosaic-debug`             | global        | `0`                                      | Set to `1` to log to `@mosaic-log-file`                 |
-| `@mosaic-log-file`          | global        | `${TMPDIR:-/tmp}/tmux-mosaic-$(uid).log` | Log path when debug on                                  |
+| Option                      | Scope         | Default                                    | Purpose                                                 |
+| --------------------------- | ------------- | ------------------------------------------ | ------------------------------------------------------- |
+| `@mosaic-enabled`           | window        | unset                                      | Set to `1` to tile this window                          |
+| `@mosaic-algorithm`         | window        | (uses default)                             | Per-window algorithm override                           |
+| `@mosaic-default-algorithm` | global        | `master-stack`                             | Default for windows without override                    |
+| `@mosaic-orientation`       | window→global | `left`                                     | For `master-stack`: `left`, `right`, `top`, or `bottom` |
+| `@mosaic-mfact`             | window→global | `50`                                       | Master size as percent                                  |
+| `@mosaic-step`              | global        | `5`                                        | Default `resize-master` step                            |
+| `@mosaic-debug`             | global        | `0`                                        | Set to `1` to log to `@mosaic-log-file`                 |
+| `@mosaic-log-file`          | global        | `${TMPDIR:-/tmp}/tmux-mosaic-$(id -u).log` | Log path when debug is on                               |
 
-## Algorithms
+## Documentation
 
-Each algorithm is one file under `scripts/algorithms/<name>.sh` exposing a fixed
-contract:
+- [Installation](INSTALLATION.md)
+- [Algorithms](docs/algorithms/README.md)
 
-```
-algo_relayout <window-id>      # required — apply the layout
-algo_toggle                    # required — enable/disable on this window
-algo_promote                   # optional — bring focused pane to "primary" slot
-algo_resize_master <delta>     # optional — adjust the algorithm's primary dimension
-algo_sync_state <window-id>    # optional — pull mosaic state from current tmux state
-```
+The algorithm reference is being split out in this pass and is still skeletal.
 
-The dispatcher (`scripts/ops.sh`) sources the file selected by
-`@mosaic-algorithm` (or `@mosaic-default-algorithm`) and calls the matching
-`algo_*` function. Adding an algorithm is a one-file change: drop it into
-`algorithms/`, define the contract, set `@mosaic-algorithm` on a window.
+## Limits
 
-### master-stack
+- Single master only. Tmux's native `main-*` layouts are hardcoded to one master
+  pane.
+- No per-pane stack size factors. Mosaic uses native tmux layouts, not
+  hand-rolled layout strings.
+- Hooks cover tmux structural events plus `after-select-pane`. If you force a
+  different layout or reorder panes manually, run `relayout`.
 
-Faithful to Hyprland's master layout with `nmaster=1`, `new_status=slave`,
-`new_on_top=false`. Implemented atop tmux's native `main-vertical`,
-`main-horizontal`, and mirrored variants, plus `main-pane-width <pct>%` /
-`main-pane-height <pct>%` + `swap-pane -D/-U`. The `swap-pane -D/-U` ring
-matches `MasterAlgorithm::getNextTarget` — same-category neighbor first, falls
-back across the master/stack boundary at the ring edges.
+## Acknowledgements
 
-### even-vertical
-
-Equal-height panes in a column via tmux's native `even-vertical` layout. Set
-`@mosaic-algorithm` to `even-vertical` on a window to use it.
-
-### monocle
-
-Fullscreen active pane via tmux's native zoom. Set `@mosaic-algorithm` to
-`monocle` on a window to keep the active pane zoomed as focus changes, panes
-split, and panes exit.
-
-### even-horizontal
-
-Equal-width panes in a row via tmux's native `even-horizontal` layout. Set
-`@mosaic-algorithm` to `even-horizontal` on a window to use it.
-
-### grid
-
-Equal-size panes in a grid via tmux's native `tiled` layout. Set
-`@mosaic-algorithm` to `grid` on a window to use it.
-
-## FAQ
-
-**Q: Why doesn't `promote` toggle when I'm already master?**
-
-It does, by default. On master, `promote` swaps master with stack-top (matches
-Hyprland's `swapwithmaster auto`). XMonad's no-op semantic is intentionally
-rejected — toggle is more discoverable.
-
-**Q: My splits don't auto-rebalance.**
-
-Mosaic is opt-in per window. Run `set-option -wq @mosaic-enabled 1` on the
-window, or bind `toggle` to a key.
-
-**Q: Can I tile some windows and leave others alone?**
-
-Yes — that's the design. Hooks check `@mosaic-enabled` per window before acting.
-Unset windows are inert.
-
-## Known Limitations
-
-- **Single master.** Tmux's native `main-*` layouts are hardcoded to one master
-  pane. Multi-master would require hand-rolled layout strings; intentionally out
-  of scope for v0.x.
-
-- **No per-pane height factors.** Hyprland's `percSize` lets you bias one slave
-  taller than the others. Tmux can express this via custom layout strings, but
-  mosaic uses native layouts only and stack heights are always equal-split with
-  running remainder.
-
-- **Hooks fire only on tmux's structural events.** mosaic intercepts
-  `after-split-window`, `after-kill-pane`, `pane-exited`, `pane-died`, and
-  `after-resize-pane`. Operations that bypass these (e.g. direct `select-layout`
-  to a non-`main-*` layout, or `move-pane` reordering) won't trigger relayout.
-  Run `relayout` explicitly if needed.
-
-# Acknowledgements
-
-- [Hyprland](https://github.com/hyprwm/Hyprland) — `MasterAlgorithm.cpp` is the
-  reference for `swap-next` ring semantics
-- [dwm](https://dwm.suckless.org/) and [XMonad](https://xmonad.org/) — the
-  master/stack family that started it all
-- [saysjonathan/dwm.tmux](https://github.com/saysjonathan/dwm.tmux) — closest
-  prior art for the feature space
+- [Hyprland](https://github.com/hyprwm/Hyprland)
+- [dwm](https://dwm.suckless.org/) and [XMonad](https://xmonad.org/)
+- [saysjonathan/dwm.tmux](https://github.com/saysjonathan/dwm.tmux)
 - [tmux-plugins/tmux-resurrect](https://github.com/tmux-plugins/tmux-resurrect)
-  — the `strategies/` pattern this plugin's `algorithms/` layout borrows from

--- a/docs/algorithms/README.md
+++ b/docs/algorithms/README.md
@@ -1,0 +1,16 @@
+# Algorithms
+
+This directory is the start of the algorithm reference. This first pass creates
+the structure and a minimal support matrix; the per-algorithm pages are still
+templates.
+
+| Algorithm         | Default | Backing tmux layout | Implemented ops                                  | Page                                  |
+| ----------------- | ------- | ------------------- | ------------------------------------------------ | ------------------------------------- |
+| `master-stack`    | yes     | `main-*` family     | `toggle`, `promote`, `resize-master`, `relayout` | [master-stack](master-stack.md)       |
+| `even-vertical`   | no      | `even-vertical`     | `toggle`, `relayout`                             | [even-vertical](even-vertical.md)     |
+| `even-horizontal` | no      | `even-horizontal`   | `toggle`, `relayout`                             | [even-horizontal](even-horizontal.md) |
+| `grid`            | no      | `tiled`             | `toggle`, `relayout`                             | [grid](grid.md)                       |
+| `monocle`         | no      | tmux zoom           | `toggle`, `relayout`                             | [monocle](monocle.md)                 |
+
+Algorithms that do not implement an operation will surface a message when you
+call it directly.

--- a/docs/algorithms/even-horizontal.md
+++ b/docs/algorithms/even-horizontal.md
@@ -1,0 +1,13 @@
+# even-horizontal
+
+This page is a placeholder for the full `even-horizontal` reference.
+
+## Behavior
+
+Native tmux `even-horizontal` layout.
+
+## Supported operations
+
+## Relevant options
+
+## Example use

--- a/docs/algorithms/even-vertical.md
+++ b/docs/algorithms/even-vertical.md
@@ -1,0 +1,13 @@
+# even-vertical
+
+This page is a placeholder for the full `even-vertical` reference.
+
+## Behavior
+
+Native tmux `even-vertical` layout.
+
+## Supported operations
+
+## Relevant options
+
+## Example use

--- a/docs/algorithms/grid.md
+++ b/docs/algorithms/grid.md
@@ -1,0 +1,13 @@
+# grid
+
+This page is a placeholder for the full `grid` reference.
+
+## Behavior
+
+Native tmux `tiled` layout.
+
+## Supported operations
+
+## Relevant options
+
+## Example use

--- a/docs/algorithms/master-stack.md
+++ b/docs/algorithms/master-stack.md
@@ -1,0 +1,13 @@
+# master-stack
+
+This page is a placeholder for the full `master-stack` reference.
+
+## Behavior
+
+Native tmux `main-*` layouts with one master pane and a stack.
+
+## Supported operations
+
+## Relevant options
+
+## Example use

--- a/docs/algorithms/monocle.md
+++ b/docs/algorithms/monocle.md
@@ -1,0 +1,13 @@
+# monocle
+
+This page is a placeholder for the full `monocle` reference.
+
+## Behavior
+
+Keeps the focused pane zoomed.
+
+## Supported operations
+
+## Relevant options
+
+## Example use


### PR DESCRIPTION
## Problem

Issue #10 started as a README polish pass, but the real problem was structure. The front page was carrying installation detail, usage, reference material, and FAQ all at once, which made the repo harder to scan and buried the actual surface area.

## Solution

This first pass turns the README back into a landing page, moves install detail into `INSTALLATION.md`, and creates a skeletal `docs/algorithms/` reference tree with a support matrix and per-algorithm placeholders for follow-up passes.