### PR TITLE
docs: write the algorithm reference

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -66,5 +66,6 @@ bind -r . run '#{E:@mosaic-exec} resize-master +5'
 bind T run '#{E:@mosaic-exec} toggle'
 ```
 
-For focus movement, swapping, and zoom, keep using stock tmux commands. For the
-algorithm reference, see [docs/algorithms](docs/algorithms/README.md).
+For focus movement, swapping, and zoom, keep using stock tmux commands. For
+per-algorithm behavior, supported ops, and options, see
+[docs/algorithms](docs/algorithms/README.md).

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ default.
 | `resize-master ±N` | Adjust master size by N percent, clamped to 5–95                                         |
 | `relayout`         | Force re-apply the current algorithm when you need to recover from manual layout changes |
 
+Not every algorithm implements every op. `master-stack` implements the full set;
+the other layouts support `toggle` and `relayout` only. See
+[Algorithms](docs/algorithms/README.md).
+
 For focus, swapping through the ring, and zoom, use stock tmux directly:
 
 | Want                                    | Tmux command                                              |
@@ -84,7 +88,8 @@ For focus, swapping through the ring, and zoom, use stock tmux directly:
 - [Installation](INSTALLATION.md)
 - [Algorithms](docs/algorithms/README.md)
 
-The algorithm reference is being split out in this pass and is still skeletal.
+See the algorithm pages for layout behavior, supported ops, and relevant
+options.
 
 ## Limits
 

--- a/docs/algorithms/README.md
+++ b/docs/algorithms/README.md
@@ -1,16 +1,27 @@
 # Algorithms
 
-This directory is the start of the algorithm reference. This first pass creates
-the structure and a minimal support matrix; the per-algorithm pages are still
-templates.
+Select an algorithm per window with:
 
-| Algorithm         | Default | Backing tmux layout | Implemented ops                                  | Page                                  |
-| ----------------- | ------- | ------------------- | ------------------------------------------------ | ------------------------------------- |
-| `master-stack`    | yes     | `main-*` family     | `toggle`, `promote`, `resize-master`, `relayout` | [master-stack](master-stack.md)       |
-| `even-vertical`   | no      | `even-vertical`     | `toggle`, `relayout`                             | [even-vertical](even-vertical.md)     |
-| `even-horizontal` | no      | `even-horizontal`   | `toggle`, `relayout`                             | [even-horizontal](even-horizontal.md) |
-| `grid`            | no      | `tiled`             | `toggle`, `relayout`                             | [grid](grid.md)                       |
-| `monocle`         | no      | tmux zoom           | `toggle`, `relayout`                             | [monocle](monocle.md)                 |
+```tmux
+set-option -wq @mosaic-algorithm grid
+set-option -wq @mosaic-enabled 1
+```
 
-Algorithms that do not implement an operation will surface a message when you
-call it directly.
+If a window does not set `@mosaic-algorithm`, mosaic falls back to
+`@mosaic-default-algorithm`, which defaults to `master-stack`.
+
+```tmux
+set-option -gq @mosaic-default-algorithm monocle
+```
+
+All algorithms support `toggle` and `relayout`. Unsupported operations surface a
+tmux message instead of failing hard. Mosaic only relayouts windows that are
+enabled and have more than one pane.
+
+| Algorithm         | Default | Backing tmux layout | `promote` | `resize-master` | Notes                                     | Page                                  |
+| ----------------- | ------- | ------------------- | --------- | --------------- | ----------------------------------------- | ------------------------------------- |
+| `master-stack`    | yes     | `main-*` family     | yes       | yes             | One master pane plus equal-split stack    | [master-stack](master-stack.md)       |
+| `even-vertical`   | no      | `even-vertical`     | no        | no              | Equal-height panes in one column          | [even-vertical](even-vertical.md)     |
+| `even-horizontal` | no      | `even-horizontal`   | no        | no              | Equal-width panes in one row              | [even-horizontal](even-horizontal.md) |
+| `grid`            | no      | `tiled`             | no        | no              | Equal-size grid using tmux's tiled layout | [grid](grid.md)                       |
+| `monocle`         | no      | tmux zoom           | no        | no              | Keeps the focused pane zoomed             | [monocle](monocle.md)                 |

--- a/docs/algorithms/even-horizontal.md
+++ b/docs/algorithms/even-horizontal.md
@@ -1,13 +1,36 @@
 # even-horizontal
 
-This page is a placeholder for the full `even-horizontal` reference.
+`even-horizontal` keeps panes in one row with equal widths using tmux's native
+`even-horizontal` layout.
 
 ## Behavior
 
-Native tmux `even-horizontal` layout.
+- panes are arranged left to right in a single row
+- widths stay equal-split, with at most a one-cell remainder from tmux's
+  geometry
+- splits and kills re-apply the row layout while mosaic is enabled
+- there is no primary pane, so `promote` and `resize-master` are not implemented
 
 ## Supported operations
 
+| Op                 | Support | Behavior                                         |
+| ------------------ | ------- | ------------------------------------------------ |
+| `toggle`           | yes     | Enable or disable tiling on the current window   |
+| `relayout`         | yes     | Re-apply `even-horizontal` to the current window |
+| `promote`          | no      | Surfaces a tmux message                          |
+| `resize-master ±N` | no      | Surfaces a tmux message                          |
+
 ## Relevant options
 
+No algorithm-specific options. Use `@mosaic-algorithm` to select it and
+`@mosaic-enabled` to turn it on. `@mosaic-orientation`, `@mosaic-mfact`, and
+`@mosaic-step` are ignored.
+
 ## Example use
+
+```tmux
+set-option -wq @mosaic-algorithm even-horizontal
+set-option -wq @mosaic-enabled 1
+```
+
+Use stock tmux commands for focus movement, swapping, and zoom.

--- a/docs/algorithms/even-vertical.md
+++ b/docs/algorithms/even-vertical.md
@@ -1,13 +1,36 @@
 # even-vertical
 
-This page is a placeholder for the full `even-vertical` reference.
+`even-vertical` keeps panes in one column with equal heights using tmux's native
+`even-vertical` layout.
 
 ## Behavior
 
-Native tmux `even-vertical` layout.
+- panes are stacked top to bottom in a single column
+- heights stay equal-split, with at most a one-cell remainder from tmux's
+  geometry
+- splits and kills re-apply the column layout while mosaic is enabled
+- there is no primary pane, so `promote` and `resize-master` are not implemented
 
 ## Supported operations
 
+| Op                 | Support | Behavior                                       |
+| ------------------ | ------- | ---------------------------------------------- |
+| `toggle`           | yes     | Enable or disable tiling on the current window |
+| `relayout`         | yes     | Re-apply `even-vertical` to the current window |
+| `promote`          | no      | Surfaces a tmux message                        |
+| `resize-master ±N` | no      | Surfaces a tmux message                        |
+
 ## Relevant options
 
+No algorithm-specific options. Use `@mosaic-algorithm` to select it and
+`@mosaic-enabled` to turn it on. `@mosaic-orientation`, `@mosaic-mfact`, and
+`@mosaic-step` are ignored.
+
 ## Example use
+
+```tmux
+set-option -wq @mosaic-algorithm even-vertical
+set-option -wq @mosaic-enabled 1
+```
+
+Use stock tmux commands for focus movement, swapping, and zoom.

--- a/docs/algorithms/grid.md
+++ b/docs/algorithms/grid.md
@@ -1,13 +1,35 @@
 # grid
 
-This page is a placeholder for the full `grid` reference.
+`grid` uses tmux's native `tiled` layout for an equal-size grid.
 
 ## Behavior
 
-Native tmux `tiled` layout.
+- tmux chooses the row and column shape from the current pane count
+- with four panes, the layout becomes a 2x2 grid
+- pane widths and heights stay balanced, with at most a one-cell remainder from
+  tmux's geometry
+- there is no primary pane, so `promote` and `resize-master` are not implemented
 
 ## Supported operations
 
+| Op                 | Support | Behavior                               |
+| ------------------ | ------- | -------------------------------------- |
+| `toggle`           | yes     | Enable or disable tiling on the window |
+| `relayout`         | yes     | Re-apply tmux's `tiled` layout         |
+| `promote`          | no      | Surfaces a tmux message                |
+| `resize-master ±N` | no      | Surfaces a tmux message                |
+
 ## Relevant options
 
+No algorithm-specific options. Use `@mosaic-algorithm` to select it and
+`@mosaic-enabled` to turn it on. `@mosaic-orientation`, `@mosaic-mfact`, and
+`@mosaic-step` are ignored.
+
 ## Example use
+
+```tmux
+set-option -wq @mosaic-algorithm grid
+set-option -wq @mosaic-enabled 1
+```
+
+Use stock tmux commands for focus movement, swapping, and zoom.

--- a/docs/algorithms/master-stack.md
+++ b/docs/algorithms/master-stack.md
@@ -1,13 +1,56 @@
 # master-stack
 
-This page is a placeholder for the full `master-stack` reference.
+`master-stack` is the default algorithm. It keeps one primary pane and an
+equal-split stack using tmux's `main-*` layouts.
 
 ## Behavior
 
-Native tmux `main-*` layouts with one master pane and a stack.
+- `left` uses `main-vertical`
+- `right` uses `main-vertical-mirrored`
+- `top` uses `main-horizontal`
+- `bottom` uses `main-horizontal-mirrored`
+- the master is the first pane in tmux's pane order: pane 1 when
+  `pane-base-index` is 1, or pane 0 when it is 0
+- killing the master promotes the stack-top on the next relayout
+- drag-resizing the master updates `@mosaic-mfact`, so the next relayout keeps
+  that size
+- zoomed panes do not rewrite `@mosaic-mfact`
 
 ## Supported operations
 
+| Op                 | Behavior                                                          |
+| ------------------ | ----------------------------------------------------------------- |
+| `toggle`           | Enable or disable tiling on the current window                    |
+| `relayout`         | Re-apply the current orientation and current `@mosaic-mfact`      |
+| `promote`          | Focused stack pane becomes master. On master: swap with stack-top |
+| `resize-master ±N` | Change `@mosaic-mfact` for the current window, clamped to 5–95    |
+
 ## Relevant options
 
+| Option                | Scope         | Default | Effect                                                         |
+| --------------------- | ------------- | ------- | -------------------------------------------------------------- |
+| `@mosaic-orientation` | window→global | `left`  | Chooses `left`, `right`, `top`, or `bottom`                    |
+| `@mosaic-mfact`       | window→global | `50`    | Stores the master size as a percent                            |
+| `@mosaic-step`        | global        | `5`     | Used by `resize-master` when you call it without an explicit N |
+
 ## Example use
+
+```tmux
+set-option -wq @mosaic-algorithm master-stack
+set-option -wq @mosaic-enabled 1
+set-option -wq @mosaic-orientation right
+
+bind Enter run '#{E:@mosaic-exec} promote'
+bind -r , run '#{E:@mosaic-exec} resize-master -5'
+bind -r . run '#{E:@mosaic-exec} resize-master +5'
+```
+
+Stock tmux still handles focus movement, swapping through the ring, and zoom:
+
+```tmux
+bind a select-pane -t :.+
+bind f select-pane -t :.-
+bind d swap-pane -D
+bind u swap-pane -U
+bind z resize-pane -Z
+```

--- a/docs/algorithms/monocle.md
+++ b/docs/algorithms/monocle.md
@@ -1,13 +1,43 @@
 # monocle
 
-This page is a placeholder for the full `monocle` reference.
+`monocle` keeps the focused pane zoomed using tmux's native zoom support.
 
 ## Behavior
 
-Keeps the focused pane zoomed.
+- when enabled on a window with more than one pane, the focused pane stays
+  zoomed
+- splitting the zoomed pane keeps the new pane zoomed
+- selecting another pane re-zooms the new active pane because mosaic relayouts
+  on `after-select-pane`
+- there is no primary pane or master size, so `promote` and `resize-master` are
+  not implemented
 
 ## Supported operations
 
+| Op                 | Support | Behavior                                         |
+| ------------------ | ------- | ------------------------------------------------ |
+| `toggle`           | yes     | Enable or disable monocle on the current window  |
+| `relayout`         | yes     | Re-zoom the active pane if the window is enabled |
+| `promote`          | no      | Surfaces a tmux message                          |
+| `resize-master ±N` | no      | Surfaces a tmux message                          |
+
 ## Relevant options
 
+No algorithm-specific options. Use `@mosaic-algorithm` to select it and
+`@mosaic-enabled` to turn it on. `@mosaic-orientation`, `@mosaic-mfact`, and
+`@mosaic-step` are ignored.
+
 ## Example use
+
+```tmux
+set-option -wq @mosaic-algorithm monocle
+set-option -wq @mosaic-enabled 1
+```
+
+Mosaic does not install focus bindings. Use stock tmux commands to choose which
+pane becomes zoomed:
+
+```tmux
+bind n select-pane -t :.+
+bind p select-pane -t :.-
+```


### PR DESCRIPTION
## Problem

The docs split in #24 created the right shape, but the algorithm pages were still placeholders. The README now pointed at a reference that existed structurally but did not yet explain the real behavior, supported operations, or relevant options for each layout.

## Solution

Write the per-algorithm reference pages from the implementation and integration tests, add a real overview and support matrix, and tighten the top-level docs so they point at the reference as a finished part of the docs set instead of a skeletal stub.