### PR TITLE
fix: let window algorithm selection imply enabled

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -51,11 +51,19 @@ Reload tmux if it is already running:
 tmux source-file ~/.tmux.conf
 ```
 
-Enable mosaic on the current window:
+Use the default `master-stack` layout on the current window:
 
 ```tmux
 set-option -wq @mosaic-enabled 1
 ```
+
+Or pick a specific algorithm on the current window:
+
+```tmux
+set-option -wq @mosaic-algorithm grid
+```
+
+Setting `@mosaic-algorithm` on a window implies enabled.
 
 Optional example bindings:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tmux-mosaic
 
-**Opt-in pane tiling layouts for tmux**
+**Pane tiling layouts for tmux**
 
 A small tmux plugin for per-window pane tiling. Mosaic uses native tmux layouts
 where possible and installs no default keybindings.
@@ -27,17 +27,20 @@ Full behavior, supported ops, and relevant options live in
 
 ## Quick start
 
-Enable mosaic on the current window:
+Use the default `master-stack` layout on the current window:
 
 ```tmux
 set-option -wq @mosaic-enabled 1
 ```
 
-Pick a non-default algorithm if you want one:
+Or pick a specific algorithm on the current window:
 
 ```tmux
 set-option -wq @mosaic-algorithm grid
 ```
+
+Setting `@mosaic-algorithm` on a window implies enabled. `@mosaic-enabled`
+remains the explicit on or off override.
 
 Add your own bindings if you want them. Mosaic exports `@mosaic-exec` so the
 same bindings work across TPM, manual, and nix installs.
@@ -65,7 +68,9 @@ Not every algorithm implements every op. `master-stack` implements the full set;
 the other layouts support `toggle` and `relayout` only. See
 [Algorithms](docs/algorithms/README.md).
 
-`@mosaic-enabled` is window-scoped. Unset windows are untouched.
+`@mosaic-enabled` is window-scoped. If it is unset, a window-specific
+`@mosaic-algorithm` still activates mosaic for that window. Set
+`@mosaic-enabled` to `0` to suppress a configured window algorithm.
 
 For focus movement, swapping through the ring, and zoom, use stock tmux
 directly:
@@ -79,16 +84,16 @@ directly:
 
 ## Options
 
-| Option                      | Scope         | Default                                    | Purpose                                                 |
-| --------------------------- | ------------- | ------------------------------------------ | ------------------------------------------------------- |
-| `@mosaic-enabled`           | window        | unset                                      | Set to `1` to tile this window                          |
-| `@mosaic-algorithm`         | window        | (uses default)                             | Per-window algorithm override                           |
-| `@mosaic-default-algorithm` | global        | `master-stack`                             | Default for windows without override                    |
-| `@mosaic-orientation`       | window→global | `left`                                     | For `master-stack`: `left`, `right`, `top`, or `bottom` |
-| `@mosaic-mfact`             | window→global | `50`                                       | Master size as percent                                  |
-| `@mosaic-step`              | global        | `5`                                        | Default `resize-master` step                            |
-| `@mosaic-debug`             | global        | `0`                                        | Set to `1` to log to `@mosaic-log-file`                 |
-| `@mosaic-log-file`          | global        | `${TMPDIR:-/tmp}/tmux-mosaic-$(id -u).log` | Log path when debug is on                               |
+| Option                      | Scope         | Default                                    | Purpose                                                                                               |
+| --------------------------- | ------------- | ------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| `@mosaic-enabled`           | window        | unset                                      | Explicit on or off override. Set `1` for the default algorithm; set `0` to suppress a window override |
+| `@mosaic-algorithm`         | window        | (uses default)                             | Per-window algorithm override                                                                         |
+| `@mosaic-default-algorithm` | global        | `master-stack`                             | Default for enabled windows without a window override                                                 |
+| `@mosaic-orientation`       | window→global | `left`                                     | For `master-stack`: `left`, `right`, `top`, or `bottom`                                               |
+| `@mosaic-mfact`             | window→global | `50`                                       | Master size as percent                                                                                |
+| `@mosaic-step`              | global        | `5`                                        | Default `resize-master` step                                                                          |
+| `@mosaic-debug`             | global        | `0`                                        | Set to `1` to log to `@mosaic-log-file`                                                               |
+| `@mosaic-log-file`          | global        | `${TMPDIR:-/tmp}/tmux-mosaic-$(id -u).log` | Log path when debug is on                                                                             |
 
 ## Limits
 

--- a/docs/algorithms/README.md
+++ b/docs/algorithms/README.md
@@ -4,10 +4,18 @@ Select an algorithm per window with:
 
 ```tmux
 set-option -wq @mosaic-algorithm grid
+```
+
+Setting `@mosaic-algorithm` on a window implies enabled.
+
+Use `@mosaic-enabled 1` when you want the current window to use the default
+algorithm without setting a window override:
+
+```tmux
 set-option -wq @mosaic-enabled 1
 ```
 
-If a window does not set `@mosaic-algorithm`, mosaic falls back to
+If an enabled window does not set `@mosaic-algorithm`, mosaic falls back to
 `@mosaic-default-algorithm`, which defaults to `master-stack`.
 
 ```tmux
@@ -16,7 +24,8 @@ set-option -gq @mosaic-default-algorithm monocle
 
 All algorithms support `toggle` and `relayout`. Unsupported operations surface a
 tmux message instead of failing hard. Mosaic only relayouts windows that are
-enabled and have more than one pane.
+enabled and have more than one pane. Set `@mosaic-enabled` to `0` if you want to
+suppress a window-specific `@mosaic-algorithm`.
 
 | Algorithm         | Default | Backing tmux layout | `promote` | `resize-master` | Notes                                     | Page                                  |
 | ----------------- | ------- | ------------------- | --------- | --------------- | ----------------------------------------- | ------------------------------------- |

--- a/docs/algorithms/even-horizontal.md
+++ b/docs/algorithms/even-horizontal.md
@@ -22,15 +22,14 @@
 
 ## Relevant options
 
-No algorithm-specific options. Use `@mosaic-algorithm` to select it and
-`@mosaic-enabled` to turn it on. `@mosaic-orientation`, `@mosaic-mfact`, and
-`@mosaic-step` are ignored.
+No algorithm-specific options. Set `@mosaic-algorithm` to `even-horizontal` to
+select it; that implies enabled unless `@mosaic-enabled` is explicitly `0`.
+`@mosaic-orientation`, `@mosaic-mfact`, and `@mosaic-step` are ignored.
 
 ## Example use
 
 ```tmux
 set-option -wq @mosaic-algorithm even-horizontal
-set-option -wq @mosaic-enabled 1
 ```
 
 Use stock tmux commands for focus movement, swapping, and zoom.

--- a/docs/algorithms/even-vertical.md
+++ b/docs/algorithms/even-vertical.md
@@ -22,15 +22,14 @@
 
 ## Relevant options
 
-No algorithm-specific options. Use `@mosaic-algorithm` to select it and
-`@mosaic-enabled` to turn it on. `@mosaic-orientation`, `@mosaic-mfact`, and
-`@mosaic-step` are ignored.
+No algorithm-specific options. Set `@mosaic-algorithm` to `even-vertical` to
+select it; that implies enabled unless `@mosaic-enabled` is explicitly `0`.
+`@mosaic-orientation`, `@mosaic-mfact`, and `@mosaic-step` are ignored.
 
 ## Example use
 
 ```tmux
 set-option -wq @mosaic-algorithm even-vertical
-set-option -wq @mosaic-enabled 1
 ```
 
 Use stock tmux commands for focus movement, swapping, and zoom.

--- a/docs/algorithms/grid.md
+++ b/docs/algorithms/grid.md
@@ -21,15 +21,14 @@
 
 ## Relevant options
 
-No algorithm-specific options. Use `@mosaic-algorithm` to select it and
-`@mosaic-enabled` to turn it on. `@mosaic-orientation`, `@mosaic-mfact`, and
-`@mosaic-step` are ignored.
+No algorithm-specific options. Set `@mosaic-algorithm` to `grid` to select it;
+that implies enabled unless `@mosaic-enabled` is explicitly `0`.
+`@mosaic-orientation`, `@mosaic-mfact`, and `@mosaic-step` are ignored.
 
 ## Example use
 
 ```tmux
 set-option -wq @mosaic-algorithm grid
-set-option -wq @mosaic-enabled 1
 ```
 
 Use stock tmux commands for focus movement, swapping, and zoom.

--- a/docs/algorithms/master-stack.md
+++ b/docs/algorithms/master-stack.md
@@ -37,12 +37,17 @@ equal-split stack using tmux's `main-*` layouts.
 
 ```tmux
 set-option -wq @mosaic-algorithm master-stack
-set-option -wq @mosaic-enabled 1
 set-option -wq @mosaic-orientation right
 
 bind Enter run '#{E:@mosaic-exec} promote'
 bind -r , run '#{E:@mosaic-exec} resize-master -5'
 bind -r . run '#{E:@mosaic-exec} resize-master +5'
+```
+
+Or use the current default `master-stack` layout without a window override:
+
+```tmux
+set-option -wq @mosaic-enabled 1
 ```
 
 Stock tmux still handles focus movement, swapping through the ring, and zoom:

--- a/docs/algorithms/monocle.md
+++ b/docs/algorithms/monocle.md
@@ -23,15 +23,14 @@
 
 ## Relevant options
 
-No algorithm-specific options. Use `@mosaic-algorithm` to select it and
-`@mosaic-enabled` to turn it on. `@mosaic-orientation`, `@mosaic-mfact`, and
-`@mosaic-step` are ignored.
+No algorithm-specific options. Set `@mosaic-algorithm` to `monocle` to select
+it; that implies enabled unless `@mosaic-enabled` is explicitly `0`.
+`@mosaic-orientation`, `@mosaic-mfact`, and `@mosaic-step` are ignored.
 
 ## Example use
 
 ```tmux
 set-option -wq @mosaic-algorithm monocle
-set-option -wq @mosaic-enabled 1
 ```
 
 Mosaic does not install focus bindings. Use stock tmux commands to choose which

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -18,11 +18,31 @@ mosaic_get_w() {
   printf '%s\n' "${val:-$default}"
 }
 
+mosaic_get_w_raw() {
+  local opt="$1" target="${2:-}"
+  local val
+  if [[ -n "$target" ]]; then
+    val=$(tmux show-option -wqv -t "$target" "$opt" 2>/dev/null)
+  else
+    val=$(tmux show-option -wqv "$opt" 2>/dev/null)
+  fi
+  printf '%s\n' "$val"
+}
+
+mosaic_window_has_algorithm() {
+  local target="${1:-}"
+  [[ -n "$(mosaic_get_w_raw "@mosaic-algorithm" "$target")" ]]
+}
+
 mosaic_enabled() {
   local target="${1:-}"
   local val
-  val=$(mosaic_get_w "@mosaic-enabled" "0" "$target")
-  [[ "$val" == "1" ]] || [[ "$val" == "on" ]] || [[ "$val" == "true" ]]
+  val=$(mosaic_get_w_raw "@mosaic-enabled" "$target")
+  case "$val" in
+  1 | on | true) return 0 ;;
+  0 | off | false) return 1 ;;
+  esac
+  mosaic_window_has_algorithm "$target"
 }
 
 mosaic_current_window() { tmux display-message -p '#{window_id}'; }
@@ -68,7 +88,11 @@ mosaic_toggle_window() {
   local relayout_fn="$1" win
   win=$(mosaic_current_window)
   if mosaic_enabled "$win"; then
-    tmux set-option -wqu -t "$win" "@mosaic-enabled" 2>/dev/null
+    if mosaic_window_has_algorithm "$win"; then
+      tmux set-option -wq -t "$win" "@mosaic-enabled" 0
+    else
+      tmux set-option -wqu -t "$win" "@mosaic-enabled" 2>/dev/null
+    fi
     mosaic_show_message "mosaic: off"
   else
     tmux set-option -wq -t "$win" "@mosaic-enabled" 1

--- a/tests/integration/even_horizontal.bats
+++ b/tests/integration/even_horizontal.bats
@@ -5,7 +5,6 @@ load '../helpers.bash'
 setup() {
   mosaic_setup_server
   mosaic_t set-option -wq -t t:1 "@mosaic-algorithm" "even-horizontal"
-  mosaic_enable
 }
 
 teardown() {

--- a/tests/integration/even_vertical.bats
+++ b/tests/integration/even_vertical.bats
@@ -5,7 +5,6 @@ load '../helpers.bash'
 setup() {
   mosaic_setup_server
   mosaic_t set-option -wq -t t:1 "@mosaic-algorithm" "even-vertical"
-  mosaic_enable
 }
 
 teardown() {

--- a/tests/integration/grid.bats
+++ b/tests/integration/grid.bats
@@ -5,7 +5,6 @@ load '../helpers.bash'
 setup() {
   mosaic_setup_server
   mosaic_t set-option -wq -t t:1 "@mosaic-algorithm" "grid"
-  mosaic_enable
 }
 
 teardown() {

--- a/tests/integration/master_stack.bats
+++ b/tests/integration/master_stack.bats
@@ -224,6 +224,26 @@ assert_orientation_layout() {
   [ -z "$(mosaic_t show-option -wqv -t t:1 @mosaic-enabled)" ]
 }
 
+@test "window-specific algorithm: toggle off writes 0 and disables relayout" {
+  mosaic_t set-option -wq -t t:1 "@mosaic-algorithm" "even-vertical"
+  mosaic_t set-option -wqu -t t:1 "@mosaic-enabled"
+  for _ in 1 2; do mosaic_split; done
+
+  layout=$(mosaic_layout)
+  [[ "$layout" == *"["* ]]
+  [[ "$layout" != *"{"* ]]
+
+  mosaic_op toggle
+  [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-enabled)" = "0" ]
+
+  mosaic_t select-layout -t t:1 even-horizontal
+  mosaic_op relayout
+
+  layout=$(mosaic_layout)
+  [[ "$layout" == *"{"* ]]
+  [[ "$layout" != *"["* ]]
+}
+
 @test "unknown algorithm: dispatcher errors cleanly" {
   mosaic_t set-option -gq "@mosaic-default-algorithm" "nonexistent-algo"
   run mosaic_exec_direct focus-next

--- a/tests/integration/monocle.bats
+++ b/tests/integration/monocle.bats
@@ -19,25 +19,18 @@ active_pane_id() {
   mosaic_t display-message -p -t "${1:-t:1}" '#{pane_id}'
 }
 
-@test "monocle: toggle on zooms the focused pane" {
+@test "monocle: window algorithm keeps the focused pane zoomed" {
   for _ in 1 2; do mosaic_split; done
   mosaic_t select-pane -t t:1.2
   pid=$(active_pane_id)
 
-  [ "$(window_zoomed)" = "0" ]
-
-  mosaic_op toggle
   sleep 0.2
 
-  [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-enabled)" = "1" ]
   [ "$(window_zoomed)" = "1" ]
   [ "$(active_pane_id)" = "$pid" ]
 }
 
 @test "monocle: split keeps the new pane zoomed" {
-  mosaic_op toggle
-  sleep 0.2
-
   mosaic_split
 
   [ "$(mosaic_pane_count)" = "2" ]
@@ -47,9 +40,6 @@ active_pane_id() {
 
 @test "monocle: selecting the next pane re-zooms the new active pane" {
   for _ in 1 2; do mosaic_split; done
-
-  mosaic_op toggle
-  sleep 0.2
 
   before=$(active_pane_id)
 


### PR DESCRIPTION
## Problem

Mosaic required a double opt-in for non-default window layouts: setting `@mosaic-algorithm` alone was not enough to activate the selected layout, so users also had to set `@mosaic-enabled 1` on the same window. That made per-window layout selection more awkward than it needed to be.

## Solution

Treat a window-local `@mosaic-algorithm` as implicitly enabled unless `@mosaic-enabled` is explicitly set off, update toggle semantics so configured windows can still be disabled, add test coverage for the new behavior, and rewrite the docs to match.