### PR TITLE
chore(format): replace Prettier with Biome

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,9 +1,0 @@
-{
-  "proseWrap": "always",
-  "printWidth": 80,
-  "tabWidth": 2,
-  "useTabs": false,
-  "trailingComma": "none",
-  "semi": false,
-  "singleQuote": true
-}

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
+  "formatter": {
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineEnding": "lf",
+    "lineWidth": 80,
+    "useEditorconfig": true
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "trailingCommas": "none",
+      "semicolons": "asNeeded"
+    }
+  }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,7 @@
                 ".github"
                 ".gitignore"
                 ".editorconfig"
-                ".prettierrc"
+                "biome.json"
                 "flake.nix"
                 "flake.lock"
                 "justfile"
@@ -53,10 +53,10 @@
         pkgs:
         let
           common = [
+            pkgs.biome
             pkgs.bats
             pkgs.shellcheck
             pkgs.shfmt
-            pkgs.prettier
             pkgs.tmux
             pkgs.just
           ];

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ default:
 format:
     nix fmt -- --ci
     shfmt -i 2 -d mosaic.tmux scripts tests
-    prettier --check .
+    biome format .
 
 lint:
     shellcheck -x --source-path=SCRIPTDIR --source-path=SCRIPTDIR/scripts mosaic.tmux scripts/*.sh scripts/algorithms/*.sh tests/helpers.bash


### PR DESCRIPTION
## Problem

The repo still used Prettier for formatting checks in its just and Nix workflows, so local and CI formatting depended on a separate formatter.

## Solution

Replace Prettier with Biome in the format workflow and dev shells, add `biome.json`, remove `.prettierrc`, run Biome in write mode, and verify the change with the existing `just ci` and `just build` commands.