### PR TITLE
refactor: make @mosaic-algorithm the only layout switch

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -58,7 +58,6 @@ body:
         set -g base-index 1
         set -g pane-base-index 1
         run-shell ~/path/to/tmux-mosaic/mosaic.tmux
-        set-option -wg @mosaic-enabled 1
     validations:
       required: true
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -51,27 +51,33 @@ Reload tmux if it is already running:
 tmux source-file ~/.tmux.conf
 ```
 
-Use the default `master-stack` layout on the current window:
+Select a layout on the current window:
 
 ```tmux
-set-option -wq @mosaic-enabled 1
+set-option -wq @mosaic-algorithm master-stack
 ```
 
-Or pick a specific layout on the current window:
+Switch layouts by setting a different value:
 
 ```tmux
 set-option -wq @mosaic-algorithm grid
 ```
 
-Setting `@mosaic-algorithm` on a window implies enabled.
+Unset it to turn mosaic off on that window:
+
+```tmux
+set-option -wqu @mosaic-algorithm
+```
 
 Optional example bindings:
 
 ```tmux
+bind M set-option -wq @mosaic-algorithm master-stack
+bind G set-option -wq @mosaic-algorithm grid
+bind T set-option -wqu @mosaic-algorithm
 bind Enter run '#{E:@mosaic-exec} promote'
 bind -r , run '#{E:@mosaic-exec} resize-master -5'
 bind -r . run '#{E:@mosaic-exec} resize-master +5'
-bind T run '#{E:@mosaic-exec} toggle'
 ```
 
 For focus movement, swapping, and zoom, keep using stock tmux commands. For

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Pane tiling layouts for tmux**
 
-A small tmux plugin for per-window pane tiling. Mosaic uses native tmux layouts
+A tmux plugin for pane tiling layouts. Mosaic uses native tmux layouts
 where possible and installs no default keybindings.
 
 ## Dependencies
@@ -16,8 +16,8 @@ TPM, manual, and nix setup live in [INSTALLATION.md](INSTALLATION.md).
 
 ## [Layouts](docs/layouts/)
 
-- [`master-stack`](docs/layouts/master-stack.md#master-stack) — default; one
-  master pane plus equal-split stack
+- [`master-stack`](docs/layouts/master-stack.md#master-stack) — one master pane
+  plus equal-split stack
 - [`even-vertical`](docs/layouts/even-vertical.md#even-vertical) — equal-height
   column
 - [`even-horizontal`](docs/layouts/even-horizontal.md#even-horizontal) —
@@ -27,82 +27,37 @@ TPM, manual, and nix setup live in [INSTALLATION.md](INSTALLATION.md).
 
 ## Quick Start
 
-Use the default `master-stack` layout on the current window:
+Use `master-stack` on the current window:
 
 ```tmux
-set-option -wq @mosaic-enabled 1
+set-option -wq @mosaic-algorithm master-stack
 ```
-
-Or pick a specific layout on the current window:
-
-```tmux
-set-option -wq @mosaic-algorithm grid
-```
-
-Setting `@mosaic-algorithm` on a window implies enabled. `@mosaic-enabled`
-remains the explicit on or off override.
 
 Add your own bindings if you want them. Mosaic exports `@mosaic-exec` so the
 same bindings work across TPM, manual, and nix installs.
 
 ```tmux
+bind M set-option -wq @mosaic-algorithm master-stack
 bind Enter run '#{E:@mosaic-exec} promote'
 bind -r , run '#{E:@mosaic-exec} resize-master -5'
 bind -r . run '#{E:@mosaic-exec} resize-master +5'
 bind T run '#{E:@mosaic-exec} toggle'
 ```
 
+Unset it to turn mosaic off on that window:
+
+```tmux
+set-option -wqu @mosaic-algorithm
+```
+
 Bindings shown here are examples only. Mosaic does not install any bindings by
 default.
 
-## Operations
+For `master-stack` behavior, supported operations, and options, see
+[`docs/layouts/master-stack.md`](docs/layouts/master-stack.md).
 
-| Op                 | Behavior                                                                                 |
-| ------------------ | ---------------------------------------------------------------------------------------- |
-| `toggle`           | Enable or disable tiling on the current window                                           |
-| `promote`          | Move the focused stack pane to master. On master: swap with stack-top                    |
-| `resize-master ±N` | Adjust master size by N percent, clamped to 5–95                                         |
-| `relayout`         | Force re-apply the current algorithm when you need to recover from manual layout changes |
-
-Not every layout implements every op. `master-stack` implements the full set;
-the other layouts support `toggle` and `relayout` only. See
-[Layouts](docs/layouts/).
-
-`@mosaic-enabled` is window-scoped. If it is unset, a window-specific
-`@mosaic-algorithm` still activates mosaic for that window. Set
-`@mosaic-enabled` to `0` to suppress a configured window algorithm.
-
-For focus movement, swapping through the ring, and zoom, use stock tmux
-directly:
-
-| Want                                    | Tmux command                                              |
-| --------------------------------------- | --------------------------------------------------------- |
-| Focus next or previous pane in the ring | `select-pane -t :.+` / `:.-`                              |
-| Focus the master                        | `select-pane -t :.1` (or `:.0` if `pane-base-index` is 0) |
-| Swap the focused pane through the ring  | `swap-pane -D` / `-U`                                     |
-| Zoom the focused pane                   | `resize-pane -Z`                                          |
-
-## Options
-
-| Option                      | Scope         | Default                                    | Purpose                                                                                               |
-| --------------------------- | ------------- | ------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
-| `@mosaic-enabled`           | window        | unset                                      | Explicit on or off override. Set `1` for the default algorithm; set `0` to suppress a window override |
-| `@mosaic-algorithm`         | window        | (uses default)                             | Per-window algorithm override                                                                         |
-| `@mosaic-default-algorithm` | global        | `master-stack`                             | Default for enabled windows without a window override                                                 |
-| `@mosaic-orientation`       | window→global | `left`                                     | For `master-stack`: `left`, `right`, `top`, or `bottom`                                               |
-| `@mosaic-mfact`             | window→global | `50`                                       | Master size as percent                                                                                |
-| `@mosaic-step`              | global        | `5`                                        | Default `resize-master` step                                                                          |
-| `@mosaic-debug`             | global        | `0`                                        | Set to `1` to log to `@mosaic-log-file`                                                               |
-| `@mosaic-log-file`          | global        | `${TMPDIR:-/tmp}/tmux-mosaic-$(id -u).log` | Log path when debug is on                                                                             |
-
-## Limitations
-
-- Single master only. Tmux's native `main-*` layouts are hardcoded to one master
-  pane.
-- No per-pane stack size factors. Mosaic uses native tmux layouts, not
-  hand-rolled layout strings.
-- Hooks cover tmux structural events plus `after-select-pane`. If you force a
-  different layout or reorder panes manually, run `relayout`.
+For other layouts, layout-specific behavior, and the per-layout support matrix,
+see [Layouts](docs/layouts/).
 
 ## Acknowledgements
 

--- a/docs/layouts/README.md
+++ b/docs/layouts/README.md
@@ -6,31 +6,22 @@ Select a layout per window with:
 set-option -wq @mosaic-algorithm grid
 ```
 
-Setting `@mosaic-algorithm` on a window implies enabled.
-
-Use `@mosaic-enabled 1` when you want the current window to use the default
-layout without setting a window override:
+Unset it to turn mosaic off on that window:
 
 ```tmux
-set-option -wq @mosaic-enabled 1
-```
-
-If an enabled window does not set `@mosaic-algorithm`, mosaic falls back to
-`@mosaic-default-algorithm`, which defaults to `master-stack`.
-
-```tmux
-set-option -gq @mosaic-default-algorithm monocle
+set-option -wqu @mosaic-algorithm
 ```
 
 All layouts support `toggle` and `relayout`. Unsupported operations surface a
-tmux message instead of failing hard. Mosaic only relayouts windows that are
-enabled and have more than one pane. Set `@mosaic-enabled` to `0` if you want to
-suppress a window-specific `@mosaic-algorithm`.
+tmux message instead of failing hard. `toggle` turns the current window layout
+off. Mosaic only relayouts windows whose `@mosaic-algorithm` is set and that
+have more than one pane. Invalid algorithm names fail when an operation tries
+to load them.
 
-| Layout            | Default | Backing tmux layout | `promote` | `resize-master` | Notes                                     | Page                                  |
-| ----------------- | ------- | ------------------- | --------- | --------------- | ----------------------------------------- | ------------------------------------- |
-| `master-stack`    | yes     | `main-*` family     | yes       | yes             | One master pane plus equal-split stack    | [master-stack](master-stack.md)       |
-| `even-vertical`   | no      | `even-vertical`     | no        | no              | Equal-height panes in one column          | [even-vertical](even-vertical.md)     |
-| `even-horizontal` | no      | `even-horizontal`   | no        | no              | Equal-width panes in one row              | [even-horizontal](even-horizontal.md) |
-| `grid`            | no      | `tiled`             | no        | no              | Equal-size grid using tmux's tiled layout | [grid](grid.md)                       |
-| `monocle`         | no      | tmux zoom           | no        | no              | Keeps the focused pane zoomed             | [monocle](monocle.md)                 |
+| Layout            | Backing tmux layout | `promote` | `resize-master` | Notes                                     | Page                                  |
+| ----------------- | ------------------- | --------- | --------------- | ----------------------------------------- | ------------------------------------- |
+| `master-stack`    | `main-*` family     | yes       | yes             | One master pane plus equal-split stack    | [master-stack](master-stack.md)       |
+| `even-vertical`   | `even-vertical`     | no        | no              | Equal-height panes in one column          | [even-vertical](even-vertical.md)     |
+| `even-horizontal` | `even-horizontal`   | no        | no              | Equal-width panes in one row              | [even-horizontal](even-horizontal.md) |
+| `grid`            | `tiled`             | no        | no              | Equal-size grid using tmux's tiled layout | [grid](grid.md)                       |
+| `monocle`         | tmux zoom           | no        | no              | Keeps the focused pane zoomed             | [monocle](monocle.md)                 |

--- a/docs/layouts/even-horizontal.md
+++ b/docs/layouts/even-horizontal.md
@@ -8,14 +8,15 @@
 - panes are arranged left to right in a single row
 - widths stay equal-split, with at most a one-cell remainder from tmux's
   geometry
-- splits and kills re-apply the row layout while mosaic is enabled
+- splits and kills re-apply the row layout while `@mosaic-algorithm` is set on
+  the window
 - there is no primary pane, so `promote` and `resize-master` are not implemented
 
 ## Supported operations
 
 | Op                 | Support | Behavior                                         |
 | ------------------ | ------- | ------------------------------------------------ |
-| `toggle`           | yes     | Enable or disable tiling on the current window   |
+| `toggle`           | yes     | Turn the current window layout off               |
 | `relayout`         | yes     | Re-apply `even-horizontal` to the current window |
 | `promote`          | no      | Surfaces a tmux message                          |
 | `resize-master ±N` | no      | Surfaces a tmux message                          |
@@ -23,7 +24,7 @@
 ## Relevant options
 
 No layout-specific options. Set `@mosaic-algorithm` to `even-horizontal` to
-select it; that implies enabled unless `@mosaic-enabled` is explicitly `0`.
+select it. Unset `@mosaic-algorithm` to disable mosaic on that window.
 `@mosaic-orientation`, `@mosaic-mfact`, and `@mosaic-step` are ignored.
 
 ## Example use

--- a/docs/layouts/even-vertical.md
+++ b/docs/layouts/even-vertical.md
@@ -8,22 +8,23 @@
 - panes are stacked top to bottom in a single column
 - heights stay equal-split, with at most a one-cell remainder from tmux's
   geometry
-- splits and kills re-apply the column layout while mosaic is enabled
+- splits and kills re-apply the column layout while `@mosaic-algorithm` is set
+  on the window
 - there is no primary pane, so `promote` and `resize-master` are not implemented
 
 ## Supported operations
 
 | Op                 | Support | Behavior                                       |
 | ------------------ | ------- | ---------------------------------------------- |
-| `toggle`           | yes     | Enable or disable tiling on the current window |
+| `toggle`           | yes     | Turn the current window layout off             |
 | `relayout`         | yes     | Re-apply `even-vertical` to the current window |
 | `promote`          | no      | Surfaces a tmux message                        |
 | `resize-master ±N` | no      | Surfaces a tmux message                        |
 
 ## Relevant options
 
-No layout-specific options. Set `@mosaic-algorithm` to `even-vertical` to select
-it; that implies enabled unless `@mosaic-enabled` is explicitly `0`.
+No layout-specific options. Set `@mosaic-algorithm` to `even-vertical` to
+select it. Unset `@mosaic-algorithm` to disable mosaic on that window.
 `@mosaic-orientation`, `@mosaic-mfact`, and `@mosaic-step` are ignored.
 
 ## Example use

--- a/docs/layouts/grid.md
+++ b/docs/layouts/grid.md
@@ -14,15 +14,15 @@
 
 | Op                 | Support | Behavior                               |
 | ------------------ | ------- | -------------------------------------- |
-| `toggle`           | yes     | Enable or disable tiling on the window |
+| `toggle`           | yes     | Turn the current window layout off     |
 | `relayout`         | yes     | Re-apply tmux's `tiled` layout         |
 | `promote`          | no      | Surfaces a tmux message                |
 | `resize-master ±N` | no      | Surfaces a tmux message                |
 
 ## Relevant options
 
-No layout-specific options. Set `@mosaic-algorithm` to `grid` to select it; that
-implies enabled unless `@mosaic-enabled` is explicitly `0`.
+No layout-specific options. Set `@mosaic-algorithm` to `grid` to select it.
+Unset `@mosaic-algorithm` to disable mosaic on that window.
 `@mosaic-orientation`, `@mosaic-mfact`, and `@mosaic-step` are ignored.
 
 ## Example use

--- a/docs/layouts/master-stack.md
+++ b/docs/layouts/master-stack.md
@@ -1,7 +1,7 @@
 # master-stack
 
-`master-stack` is the default layout. It keeps one primary pane and an
-equal-split stack using tmux's `main-*` layouts.
+`master-stack` keeps one primary pane and an equal-split stack using tmux's
+`main-*` layouts.
 
 ## Behavior
 
@@ -20,7 +20,7 @@ equal-split stack using tmux's `main-*` layouts.
 
 | Op                 | Behavior                                                          |
 | ------------------ | ----------------------------------------------------------------- |
-| `toggle`           | Enable or disable tiling on the current window                    |
+| `toggle`           | Turn `master-stack` off on the current window                     |
 | `relayout`         | Re-apply the current orientation and current `@mosaic-mfact`      |
 | `promote`          | Focused stack pane becomes master. On master: swap with stack-top |
 | `resize-master ±N` | Change `@mosaic-mfact` for the current window, clamped to 5–95    |
@@ -44,11 +44,7 @@ bind -r , run '#{E:@mosaic-exec} resize-master -5'
 bind -r . run '#{E:@mosaic-exec} resize-master +5'
 ```
 
-Or use the current default `master-stack` layout without a window override:
-
-```tmux
-set-option -wq @mosaic-enabled 1
-```
+Unset `@mosaic-algorithm` to turn it off on that window.
 
 Stock tmux still handles focus movement, swapping through the ring, and zoom:
 

--- a/docs/layouts/monocle.md
+++ b/docs/layouts/monocle.md
@@ -4,7 +4,7 @@
 
 ## Behavior
 
-- when enabled on a window with more than one pane, the focused pane stays
+- when selected on a window with more than one pane, the focused pane stays
   zoomed
 - splitting the zoomed pane keeps the new pane zoomed
 - selecting another pane re-zooms the new active pane because mosaic relayouts
@@ -16,16 +16,16 @@
 
 | Op                 | Support | Behavior                                         |
 | ------------------ | ------- | ------------------------------------------------ |
-| `toggle`           | yes     | Enable or disable monocle on the current window  |
-| `relayout`         | yes     | Re-zoom the active pane if the window is enabled |
+| `toggle`           | yes     | Turn the current window layout off               |
+| `relayout`         | yes     | Re-zoom the active pane on the current window    |
 | `promote`          | no      | Surfaces a tmux message                          |
 | `resize-master ±N` | no      | Surfaces a tmux message                          |
 
 ## Relevant options
 
-No layout-specific options. Set `@mosaic-algorithm` to `monocle` to select it;
-that implies enabled unless `@mosaic-enabled` is explicitly `0`.
-`@mosaic-orientation`, `@mosaic-mfact`, and `@mosaic-step` are ignored.
+No layout-specific options. Set `@mosaic-algorithm` to `monocle` to select it.
+Unset `@mosaic-algorithm` to disable mosaic on that window. `@mosaic-orientation`,
+`@mosaic-mfact`, and `@mosaic-step` are ignored.
 
 ## Example use
 

--- a/scripts/defaults.sh
+++ b/scripts/defaults.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 mosaic_set_defaults() {
-  tmux set-option -gq "@mosaic-default-algorithm" "master-stack"
   tmux set-option -gwq "@mosaic-orientation" "left"
   tmux set-option -gq "@mosaic-mfact" "50"
   tmux set-option -gq "@mosaic-step" "5"

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -36,12 +36,6 @@ mosaic_window_has_algorithm() {
 
 mosaic_enabled() {
   local target="${1:-}"
-  local val
-  val=$(mosaic_get_w_raw "@mosaic-enabled" "$target")
-  case "$val" in
-  1 | on | true) return 0 ;;
-  0 | off | false) return 1 ;;
-  esac
   mosaic_window_has_algorithm "$target"
 }
 
@@ -85,19 +79,13 @@ mosaic_can_relayout_window() {
 }
 
 mosaic_toggle_window() {
-  local relayout_fn="$1" win
+  local _relayout_fn="${1:-}" win
   win=$(mosaic_current_window)
-  if mosaic_enabled "$win"; then
-    if mosaic_window_has_algorithm "$win"; then
-      tmux set-option -wq -t "$win" "@mosaic-enabled" 0
-    else
-      tmux set-option -wqu -t "$win" "@mosaic-enabled" 2>/dev/null
-    fi
+  if mosaic_window_has_algorithm "$win"; then
+    tmux set-option -wqu -t "$win" "@mosaic-algorithm" 2>/dev/null
     mosaic_show_message "mosaic: off"
   else
-    tmux set-option -wq -t "$win" "@mosaic-enabled" 1
-    mosaic_show_message "mosaic: on"
-    "$relayout_fn" "$win"
+    mosaic_show_message "mosaic: no layout configured"
   fi
 }
 

--- a/scripts/ops.sh
+++ b/scripts/ops.sh
@@ -6,9 +6,7 @@ source "$CURRENT_DIR/helpers.sh"
 
 algorithm_for_window() {
   local win="$1"
-  local fallback
-  fallback=$(mosaic_get "@mosaic-default-algorithm" "master-stack")
-  mosaic_get_w "@mosaic-algorithm" "$fallback" "$win"
+  mosaic_get_w_raw "@mosaic-algorithm" "$win"
 }
 
 load_algorithm() {
@@ -39,6 +37,16 @@ esac
 
 target_window=$(mosaic_resolve_window "$WIN_ARG")
 algo=$(algorithm_for_window "$target_window")
+
+if [[ -z "$algo" ]]; then
+  case "$cmd" in
+  relayout | _sync-state) exit 0 ;;
+  toggle | promote | resize-master)
+    mosaic_show_message "mosaic: no layout configured"
+    exit 0
+    ;;
+  esac
+fi
 
 if ! load_algorithm "$algo"; then
   exit 1

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -29,8 +29,9 @@ mosaic_teardown_server() {
   mosaic_t kill-server 2>/dev/null || true
 }
 
-mosaic_enable() {
-  mosaic_t set-option -wq -t "${1:-t:1}" "@mosaic-enabled" 1
+mosaic_use_algorithm() {
+  local algo="${1:?algorithm required}" target="${2:-t:1}"
+  mosaic_t set-option -wq -t "$target" "@mosaic-algorithm" "$algo"
 }
 
 mosaic_split() {

--- a/tests/integration/master_stack.bats
+++ b/tests/integration/master_stack.bats
@@ -4,7 +4,7 @@ load '../helpers.bash'
 
 setup() {
   mosaic_setup_server
-  mosaic_enable
+  mosaic_use_algorithm master-stack
 }
 
 teardown() {
@@ -61,7 +61,7 @@ assert_orientation_layout() {
 
   run mosaic_t show-option -gqv @mosaic-default-algorithm
   [ "$status" -eq 0 ]
-  [ "$output" = "master-stack" ]
+  [ -z "$output" ]
 
   run mosaic_t show-option -gwqv @mosaic-orientation
   [ "$status" -eq 0 ]
@@ -169,7 +169,7 @@ assert_orientation_layout() {
 @test "resize-master on two windows is independent" {
   mosaic_split
   mosaic_t new-window -t t: "sleep 3600"
-  mosaic_t set-option -wq -t t:2 @mosaic-enabled 1
+  mosaic_use_algorithm master-stack t:2
   mosaic_t split-window -t t:2 "sleep 3600"
   sleep 0.15
 
@@ -208,25 +208,27 @@ assert_orientation_layout() {
 }
 
 @test "disabled window: splits do NOT retile" {
-  mosaic_t set-option -wqu -t t:1 "@mosaic-enabled"
+  mosaic_t set-option -wqu -t t:1 "@mosaic-algorithm"
   mosaic_split
   mosaic_split
   layout=$(mosaic_layout)
   [[ "$layout" != *"{"* ]] || [ "$(mosaic_pane_count)" -le 1 ]
 }
 
-@test "toggle: enable/disable transitions correctly" {
-  mosaic_t set-option -wqu -t t:1 "@mosaic-enabled"
-  [ -z "$(mosaic_t show-option -wqv -t t:1 @mosaic-enabled)" ]
+@test "toggle: clears the current window layout" {
+  [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-algorithm)" = "master-stack" ]
   mosaic_op toggle
-  [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-enabled)" = "1" ]
-  mosaic_op toggle
-  [ -z "$(mosaic_t show-option -wqv -t t:1 @mosaic-enabled)" ]
+  [ -z "$(mosaic_t show-option -wqv -t t:1 @mosaic-algorithm)" ]
 }
 
-@test "window-specific algorithm: toggle off writes 0 and disables relayout" {
+@test "toggle: window without a layout stays inert" {
+  mosaic_t set-option -wqu -t t:1 "@mosaic-algorithm"
+  mosaic_op toggle
+  [ -z "$(mosaic_t show-option -wqv -t t:1 @mosaic-algorithm)" ]
+}
+
+@test "toggle: clearing the window layout disables relayout" {
   mosaic_t set-option -wq -t t:1 "@mosaic-algorithm" "even-vertical"
-  mosaic_t set-option -wqu -t t:1 "@mosaic-enabled"
   for _ in 1 2; do mosaic_split; done
 
   layout=$(mosaic_layout)
@@ -234,7 +236,7 @@ assert_orientation_layout() {
   [[ "$layout" != *"{"* ]]
 
   mosaic_op toggle
-  [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-enabled)" = "0" ]
+  [ -z "$(mosaic_t show-option -wqv -t t:1 @mosaic-algorithm)" ]
 
   mosaic_t select-layout -t t:1 even-horizontal
   mosaic_op relayout
@@ -245,8 +247,8 @@ assert_orientation_layout() {
 }
 
 @test "unknown algorithm: dispatcher errors cleanly" {
-  mosaic_t set-option -gq "@mosaic-default-algorithm" "nonexistent-algo"
-  run mosaic_exec_direct focus-next
+  mosaic_t set-option -wq -t t:1 "@mosaic-algorithm" "nonexistent-algo"
+  run mosaic_exec_direct relayout
   [ "$status" -ne 0 ]
   [[ "$output" == *"unknown algorithm"* ]]
 }


### PR DESCRIPTION
## Problem

Mosaic was still split across `@mosaic-enabled`, `@mosaic-algorithm`, and a default algorithm path. That made the behavior and docs harder to follow than the plugin actually is.

## Solution

Make `@mosaic-algorithm` the only layout switch: unset means off, set means on, and invalid values fail when loaded. Update the ops, tests, and docs around that model, and trim the README down to a `master-stack` quick start with the detailed reference left in `docs/layouts/`.