### PR TITLE
fix: support global layout defaults and local overrides

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -51,19 +51,28 @@ Reload tmux if it is already running:
 tmux source-file ~/.tmux.conf
 ```
 
-Select a layout on the current window:
+Mosaic installs no default keybindings. You choose layouts with
+`@mosaic-algorithm`, and you bind operations yourself with `@mosaic-exec`.
+
+To use `master-stack` on every window by default:
 
 ```tmux
-set-option -wq @mosaic-algorithm master-stack
+set-option -gwq @mosaic-algorithm master-stack
 ```
 
-Switch layouts by setting a different value:
+To override just the current window:
 
 ```tmux
 set-option -wq @mosaic-algorithm grid
 ```
 
-Unset it to turn mosaic off on that window:
+To disable mosaic on just the current window:
+
+```tmux
+set-option -wq @mosaic-algorithm off
+```
+
+Unset the window-local value to fall back to the global setting again:
 
 ```tmux
 set-option -wqu @mosaic-algorithm
@@ -74,10 +83,12 @@ Optional example bindings:
 ```tmux
 bind M set-option -wq @mosaic-algorithm master-stack
 bind G set-option -wq @mosaic-algorithm grid
-bind T set-option -wqu @mosaic-algorithm
+bind O set-option -wq @mosaic-algorithm off
+bind U set-option -wqu @mosaic-algorithm
 bind Enter run '#{E:@mosaic-exec} promote'
 bind -r , run '#{E:@mosaic-exec} resize-master -5'
 bind -r . run '#{E:@mosaic-exec} resize-master +5'
+bind T run '#{E:@mosaic-exec} toggle'
 ```
 
 For focus movement, swapping, and zoom, keep using stock tmux commands. For

--- a/README.md
+++ b/README.md
@@ -24,12 +24,31 @@ TPM, manual, and nix setup live in [INSTALLATION.md](INSTALLATION.md).
 
 ## Quick Start
 
-tmux-mosaic does _not_ bundle keymaps. You must set them yourself.
+tmux-mosaic does _not_ bundle keymaps. You choose layouts with
+`@mosaic-algorithm`, and you bind operations yourself with `@mosaic-exec`.
 
-For example, to use the `master-stack` layout on the current window:
+To use `master-stack` on every window by default:
 
 ```tmux
-set-option -wq @mosaic-algorithm master-stack
+set-option -gwq @mosaic-algorithm master-stack
+```
+
+To override just the current window:
+
+```tmux
+set-option -wq @mosaic-algorithm grid
+```
+
+To disable mosaic on just the current window:
+
+```tmux
+set-option -wq @mosaic-algorithm off
+```
+
+Unset the window-local value to fall back to the global setting again:
+
+```tmux
+set-option -wqu @mosaic-algorithm
 ```
 
 Then, add your custom keybinds with `@mosaic-exec`:
@@ -39,12 +58,6 @@ bind Enter run '#{E:@mosaic-exec} promote'
 bind -r ,  run '#{E:@mosaic-exec} resize-master -5'
 bind -r .  run '#{E:@mosaic-exec} resize-master +5'
 bind T     run '#{E:@mosaic-exec} toggle'
-```
-
-Disable the layout as follows:
-
-```tmux
-set-option -wqu @mosaic-algorithm
 ```
 
 ## Acknowledgements

--- a/docs/layouts/README.md
+++ b/docs/layouts/README.md
@@ -1,22 +1,35 @@
 # Layouts
 
-Select a layout per window with:
+Set a global layout default for all windows with:
+
+```tmux
+set-option -gwq @mosaic-algorithm master-stack
+```
+
+Override just the current window with:
 
 ```tmux
 set-option -wq @mosaic-algorithm grid
 ```
 
-Unset it to turn mosaic off on that window:
+Disable mosaic on just the current window with:
+
+```tmux
+set-option -wq @mosaic-algorithm off
+```
+
+Unset the window-local value to fall back to the global setting again:
 
 ```tmux
 set-option -wqu @mosaic-algorithm
 ```
 
 All layouts support `toggle` and `relayout`. Unsupported operations surface a
-tmux message instead of failing hard. `toggle` turns the current window layout
-off. Mosaic only relayouts windows whose `@mosaic-algorithm` is set and that
-have more than one pane. Invalid algorithm names fail when an operation tries
-to load them.
+tmux message instead of failing hard. `toggle` disables the current window; if
+the window is locally `off` and a global layout is configured, `toggle`
+re-enables the global setting. Mosaic only relayouts windows whose effective
+`@mosaic-algorithm` resolves to a layout and that have more than one pane.
+Invalid algorithm names fail when an operation tries to load them.
 
 | Layout            | Backing tmux layout | `promote` | `resize-master` | Notes                                     | Page                                  |
 | ----------------- | ------------------- | --------- | --------------- | ----------------------------------------- | ------------------------------------- |

--- a/docs/layouts/even-horizontal.md
+++ b/docs/layouts/even-horizontal.md
@@ -8,7 +8,7 @@
 - panes are arranged left to right in a single row
 - widths stay equal-split, with at most a one-cell remainder from tmux's
   geometry
-- splits and kills re-apply the row layout while `@mosaic-algorithm` is set on
+- splits and kills re-apply the row layout while `even-horizontal` is active on
   the window
 - there is no primary pane, so `promote` and `resize-master` are not implemented
 
@@ -24,7 +24,9 @@
 ## Relevant options
 
 No layout-specific options. Set `@mosaic-algorithm` to `even-horizontal` to
-select it. Unset `@mosaic-algorithm` to disable mosaic on that window.
+select it globally or per-window. Set `@mosaic-algorithm` to `off` on a window
+to disable mosaic there. Unset the window-local value to fall back to the
+global setting again.
 `@mosaic-orientation`, `@mosaic-mfact`, and `@mosaic-step` are ignored.
 
 ## Example use

--- a/docs/layouts/even-vertical.md
+++ b/docs/layouts/even-vertical.md
@@ -8,7 +8,7 @@
 - panes are stacked top to bottom in a single column
 - heights stay equal-split, with at most a one-cell remainder from tmux's
   geometry
-- splits and kills re-apply the column layout while `@mosaic-algorithm` is set
+- splits and kills re-apply the column layout while `even-vertical` is active
   on the window
 - there is no primary pane, so `promote` and `resize-master` are not implemented
 
@@ -24,7 +24,9 @@
 ## Relevant options
 
 No layout-specific options. Set `@mosaic-algorithm` to `even-vertical` to
-select it. Unset `@mosaic-algorithm` to disable mosaic on that window.
+select it globally or per-window. Set `@mosaic-algorithm` to `off` on a window
+to disable mosaic there. Unset the window-local value to fall back to the
+global setting again.
 `@mosaic-orientation`, `@mosaic-mfact`, and `@mosaic-step` are ignored.
 
 ## Example use

--- a/docs/layouts/grid.md
+++ b/docs/layouts/grid.md
@@ -22,7 +22,8 @@
 ## Relevant options
 
 No layout-specific options. Set `@mosaic-algorithm` to `grid` to select it.
-Unset `@mosaic-algorithm` to disable mosaic on that window.
+Set `@mosaic-algorithm` to `off` on a window to disable mosaic there. Unset the
+window-local value to fall back to the global setting again.
 `@mosaic-orientation`, `@mosaic-mfact`, and `@mosaic-step` are ignored.
 
 ## Example use

--- a/docs/layouts/master-stack.md
+++ b/docs/layouts/master-stack.md
@@ -36,15 +36,16 @@
 ## Example use
 
 ```tmux
-set-option -wq @mosaic-algorithm master-stack
-set-option -wq @mosaic-orientation right
+set-option -gwq @mosaic-algorithm master-stack
+set-option -gwq @mosaic-orientation right
 
 bind Enter run '#{E:@mosaic-exec} promote'
 bind -r , run '#{E:@mosaic-exec} resize-master -5'
 bind -r . run '#{E:@mosaic-exec} resize-master +5'
 ```
 
-Unset `@mosaic-algorithm` to turn it off on that window.
+Set `@mosaic-algorithm` to `off` on a window to disable mosaic there. Unset the
+window-local value to fall back to the global setting again.
 
 Stock tmux still handles focus movement, swapping through the ring, and zoom:
 

--- a/docs/layouts/monocle.md
+++ b/docs/layouts/monocle.md
@@ -24,8 +24,9 @@
 ## Relevant options
 
 No layout-specific options. Set `@mosaic-algorithm` to `monocle` to select it.
-Unset `@mosaic-algorithm` to disable mosaic on that window. `@mosaic-orientation`,
-`@mosaic-mfact`, and `@mosaic-step` are ignored.
+Set `@mosaic-algorithm` to `off` on a window to disable mosaic there. Unset the
+window-local value to fall back to the global setting again.
+`@mosaic-orientation`, `@mosaic-mfact`, and `@mosaic-step` are ignored.
 
 ## Example use
 

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -18,6 +18,13 @@ mosaic_get_w() {
   printf '%s\n' "${val:-$default}"
 }
 
+mosaic_get_gw() {
+  local opt="$1" default="$2"
+  local val
+  val=$(tmux show-option -gwqv "$opt" 2>/dev/null)
+  printf '%s\n' "${val:-$default}"
+}
+
 mosaic_get_w_raw() {
   local opt="$1" target="${2:-}"
   local val
@@ -29,9 +36,47 @@ mosaic_get_w_raw() {
   printf '%s\n' "$val"
 }
 
+mosaic_local_algorithm() {
+  local target="${1:-}"
+  mosaic_get_w_raw "@mosaic-algorithm" "$target"
+}
+
+mosaic_global_algorithm() {
+  mosaic_get_gw "@mosaic-algorithm" ""
+}
+
+mosaic_algorithm_for_window() {
+  local target="${1:-}" val
+  val=$(mosaic_local_algorithm "$target")
+  case "$val" in
+  off)
+    printf '\n'
+    return 0
+    ;;
+  '')
+    ;;
+  *)
+    printf '%s\n' "$val"
+    return 0
+    ;;
+  esac
+
+  val=$(mosaic_global_algorithm)
+  case "$val" in
+  '' | off) printf '\n' ;;
+  *) printf '%s\n' "$val" ;;
+  esac
+}
+
+mosaic_window_has_local_algorithm() {
+  local target="${1:-}" val
+  val=$(mosaic_local_algorithm "$target")
+  [[ -n "$val" && "$val" != "off" ]]
+}
+
 mosaic_window_has_algorithm() {
   local target="${1:-}"
-  [[ -n "$(mosaic_get_w_raw "@mosaic-algorithm" "$target")" ]]
+  [[ -n "$(mosaic_algorithm_for_window "$target")" ]]
 }
 
 mosaic_enabled() {
@@ -79,10 +124,28 @@ mosaic_can_relayout_window() {
 }
 
 mosaic_toggle_window() {
-  local _relayout_fn="${1:-}" win
+  local relayout_fn="${1:-}" win local_algo global_algo
   win=$(mosaic_current_window)
-  if mosaic_window_has_algorithm "$win"; then
-    tmux set-option -wqu -t "$win" "@mosaic-algorithm" 2>/dev/null
+  local_algo=$(mosaic_local_algorithm "$win")
+  global_algo=$(mosaic_global_algorithm)
+
+  if [[ "$local_algo" == "off" ]]; then
+    if [[ -n "$global_algo" && "$global_algo" != "off" ]]; then
+      tmux set-option -wqu -t "$win" "@mosaic-algorithm" 2>/dev/null
+      mosaic_show_message "mosaic: on"
+      [[ -n "$relayout_fn" ]] && "$relayout_fn" "$win"
+    else
+      mosaic_show_message "mosaic: no layout configured"
+    fi
+  elif [[ -n "$local_algo" ]]; then
+    if [[ -n "$global_algo" && "$global_algo" != "off" ]]; then
+      tmux set-option -wq -t "$win" "@mosaic-algorithm" "off"
+    else
+      tmux set-option -wqu -t "$win" "@mosaic-algorithm" 2>/dev/null
+    fi
+    mosaic_show_message "mosaic: off"
+  elif [[ -n "$global_algo" && "$global_algo" != "off" ]]; then
+    tmux set-option -wq -t "$win" "@mosaic-algorithm" "off"
     mosaic_show_message "mosaic: off"
   else
     mosaic_show_message "mosaic: no layout configured"

--- a/scripts/ops.sh
+++ b/scripts/ops.sh
@@ -4,11 +4,6 @@ CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=helpers.sh
 source "$CURRENT_DIR/helpers.sh"
 
-algorithm_for_window() {
-  local win="$1"
-  mosaic_get_w_raw "@mosaic-algorithm" "$win"
-}
-
 load_algorithm() {
   local algo="$1"
   if [[ ! "$algo" =~ ^[a-z][a-z0-9-]*$ ]]; then
@@ -36,7 +31,12 @@ relayout | _sync-state)
 esac
 
 target_window=$(mosaic_resolve_window "$WIN_ARG")
-algo=$(algorithm_for_window "$target_window")
+local_algo=$(mosaic_local_algorithm "$target_window")
+algo=$(mosaic_algorithm_for_window "$target_window")
+
+if [[ "$cmd" == "toggle" && -z "$algo" && "$local_algo" == "off" ]]; then
+  algo=$(mosaic_global_algorithm)
+fi
 
 if [[ -z "$algo" ]]; then
   case "$cmd" in

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -34,6 +34,21 @@ mosaic_use_algorithm() {
   mosaic_t set-option -wq -t "$target" "@mosaic-algorithm" "$algo"
 }
 
+mosaic_use_global_algorithm() {
+  local algo="${1:?algorithm required}"
+  mosaic_t set-option -gwq "@mosaic-algorithm" "$algo"
+}
+
+mosaic_disable_algorithm() {
+  local target="${1:-t:1}"
+  mosaic_t set-option -wq -t "$target" "@mosaic-algorithm" "off"
+}
+
+mosaic_clear_algorithm() {
+  local target="${1:-t:1}"
+  mosaic_t set-option -wqu -t "$target" "@mosaic-algorithm"
+}
+
 mosaic_split() {
   local target="${1:-t:1}"
   mosaic_t split-window -t "$target" "sleep 3600"

--- a/tests/integration/grid.bats
+++ b/tests/integration/grid.bats
@@ -13,6 +13,7 @@ teardown() {
 
 @test "grid: 4 panes use tiled layout" {
   for _ in 1 2 3; do mosaic_split; done
+  mosaic_op relayout
   [ "$(mosaic_pane_count)" = "4" ]
 
   layout=$(mosaic_layout)

--- a/tests/integration/master_stack.bats
+++ b/tests/integration/master_stack.bats
@@ -59,7 +59,7 @@ assert_orientation_layout() {
   [ "$status" -eq 0 ]
   [ "$output" = "50" ]
 
-  run mosaic_t show-option -gqv @mosaic-default-algorithm
+  run mosaic_t show-option -gwqv @mosaic-algorithm
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 
@@ -208,26 +208,64 @@ assert_orientation_layout() {
 }
 
 @test "disabled window: splits do NOT retile" {
-  mosaic_t set-option -wqu -t t:1 "@mosaic-algorithm"
+  mosaic_clear_algorithm
   mosaic_split
   mosaic_split
   layout=$(mosaic_layout)
   [[ "$layout" != *"{"* ]] || [ "$(mosaic_pane_count)" -le 1 ]
 }
 
-@test "toggle: clears the current window layout" {
+@test "global algorithm: windows without a local override inherit it" {
+  mosaic_clear_algorithm
+  mosaic_use_global_algorithm master-stack
+  mosaic_split
+  mosaic_op relayout
+  layout=$(mosaic_layout)
+  [[ "$layout" == *"{"* ]]
+}
+
+@test "global algorithm: new windows inherit it" {
+  mosaic_t new-window -t t: "sleep 3600"
+  mosaic_use_global_algorithm master-stack
+  mosaic_split t:2
+  layout=$(mosaic_layout t:2)
+  [[ "$layout" == *"{"* ]]
+}
+
+@test "window-local algorithm overrides the global default" {
+  mosaic_clear_algorithm
+  mosaic_use_global_algorithm master-stack
+  mosaic_use_algorithm even-vertical
+  mosaic_split
+  mosaic_split
+  layout=$(mosaic_layout)
+  [[ "$layout" == *"["* ]]
+  [[ "$layout" != *"{"* ]]
+}
+
+@test "window-local off disables the global default" {
+  mosaic_clear_algorithm
+  mosaic_use_global_algorithm master-stack
+  mosaic_disable_algorithm
+  mosaic_split
+  mosaic_split
+  layout=$(mosaic_layout)
+  [[ "$layout" != *"{"* ]] || [ "$(mosaic_pane_count)" -le 1 ]
+}
+
+@test "toggle: clears the current window layout when no global default exists" {
   [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-algorithm)" = "master-stack" ]
   mosaic_op toggle
   [ -z "$(mosaic_t show-option -wqv -t t:1 @mosaic-algorithm)" ]
 }
 
 @test "toggle: window without a layout stays inert" {
-  mosaic_t set-option -wqu -t t:1 "@mosaic-algorithm"
+  mosaic_clear_algorithm
   mosaic_op toggle
   [ -z "$(mosaic_t show-option -wqv -t t:1 @mosaic-algorithm)" ]
 }
 
-@test "toggle: clearing the window layout disables relayout" {
+@test "toggle: clearing the window layout disables relayout when no global default exists" {
   mosaic_t set-option -wq -t t:1 "@mosaic-algorithm" "even-vertical"
   for _ in 1 2; do mosaic_split; done
 
@@ -244,6 +282,35 @@ assert_orientation_layout() {
   layout=$(mosaic_layout)
   [[ "$layout" == *"{"* ]]
   [[ "$layout" != *"["* ]]
+}
+
+@test "toggle: inherited global layout writes local off" {
+  mosaic_clear_algorithm
+  mosaic_use_global_algorithm master-stack
+  for _ in 1 2; do mosaic_split; done
+  [ -z "$(mosaic_t show-option -wqv -t t:1 @mosaic-algorithm)" ]
+
+  mosaic_op toggle
+  [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-algorithm)" = "off" ]
+
+  mosaic_t select-layout -t t:1 even-vertical
+  mosaic_op relayout
+
+  layout=$(mosaic_layout)
+  [[ "$layout" != *"{"* ]] || [ "$(mosaic_pane_count)" -le 1 ]
+}
+
+@test "toggle: local off can re-enable the global layout" {
+  mosaic_clear_algorithm
+  mosaic_use_global_algorithm master-stack
+  mosaic_disable_algorithm
+  for _ in 1 2; do mosaic_split; done
+
+  mosaic_op toggle
+  [ -z "$(mosaic_t show-option -wqv -t t:1 @mosaic-algorithm)" ]
+
+  layout=$(mosaic_layout)
+  [[ "$layout" == *"{"* ]]
 }
 
 @test "unknown algorithm: dispatcher errors cleanly" {


### PR DESCRIPTION
## Problem

The README still described tmux-mosaic as a per-window opt-in tool, and the code had no way to set a global `@mosaic-algorithm` default with per-window overrides or disables.

## Solution

Resolve `@mosaic-algorithm` from a global window option with window-local overrides, use `off` as the window-local disable value, and update `toggle`, tests, and docs around that model. Rewrite the README and installation/layout docs so they explain the lack of bundled keybindings, the global default flow, window-local overrides, and per-window disable.
