### PR TITLE
fix(format): scope Biome to repo files

### DIFF
--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ default:
 format:
     nix fmt -- --ci
     shfmt -i 2 -d mosaic.tmux scripts tests
-    biome format .
+    biome format biome.json README.md INSTALLATION.md docs .github
 
 lint:
     shellcheck -x --source-path=SCRIPTDIR --source-path=SCRIPTDIR/scripts mosaic.tmux scripts/*.sh scripts/algorithms/*.sh tests/helpers.bash


### PR DESCRIPTION
## Problem

`direnv exec /home/barrett/dev/tmux-mosaic just ... format` and `just ci` can walk `.direnv/flake-inputs` symlinks into Nix store sources because the Biome step formats `.` recursively.

## Solution

Limit the Biome format recipe to the repo-owned JSON and Markdown paths that Biome actually formats in this repo, so the direnv/Nix workflow stays within the worktree.