### PR TITLE
docs: add real tmux config examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,41 +24,32 @@ TPM, manual, and nix setup live in [INSTALLATION.md](INSTALLATION.md).
 
 ## Quick Start
 
-tmux-mosaic does _not_ bundle keymaps. You choose layouts with
-`@mosaic-algorithm`, and you bind operations yourself with `@mosaic-exec`.
+tmux-mosaic does _not_ bundle keymaps. A realistic setup is to pick a global
+default, bind the operations you use for that default, and bind a few
+per-window layout switches.
 
-To use `master-stack` on every window by default:
+For example, use `master-stack` everywhere by default, then swap one window to
+`grid` when it fits better:
 
 ```tmux
 set-option -gwq @mosaic-algorithm master-stack
-```
-
-To override just the current window:
-
-```tmux
-set-option -wq @mosaic-algorithm grid
-```
-
-To disable mosaic on just the current window:
-
-```tmux
-set-option -wq @mosaic-algorithm off
-```
-
-Unset the window-local value to fall back to the global setting again:
-
-```tmux
-set-option -wqu @mosaic-algorithm
-```
-
-Then, add your custom keybinds with `@mosaic-exec`:
-
-```tmux
 bind Enter run '#{E:@mosaic-exec} promote'
 bind -r ,  run '#{E:@mosaic-exec} resize-master -5'
 bind -r .  run '#{E:@mosaic-exec} resize-master +5'
 bind T     run '#{E:@mosaic-exec} toggle'
+bind G     set-option -wq @mosaic-algorithm grid
+bind V     set-option -wq @mosaic-algorithm even-vertical
+bind H     set-option -wq @mosaic-algorithm even-horizontal
+bind Z     set-option -wq @mosaic-algorithm monocle
+bind U     set-option -wqu @mosaic-algorithm
 ```
+
+Most windows now inherit `master-stack`. When one window wants `grid`, press
+`G` on that window. Press `U` to clear the local override and go back to the
+global default.
+
+Each layout page has a short tmux.conf example for wiring that layout into a
+real setup.
 
 ## Acknowledgements
 

--- a/docs/layouts/README.md
+++ b/docs/layouts/README.md
@@ -24,6 +24,9 @@ Unset the window-local value to fall back to the global setting again:
 set-option -wqu @mosaic-algorithm
 ```
 
+Each layout page includes a short tmux.conf example for using that layout in a
+real setup.
+
 All layouts support `toggle` and `relayout`. Unsupported operations surface a
 tmux message instead of failing hard. `toggle` disables the current window; if
 the window is locally `off` and a global layout is configured, `toggle`

--- a/docs/layouts/even-horizontal.md
+++ b/docs/layouts/even-horizontal.md
@@ -6,8 +6,6 @@
 ## Behavior
 
 - panes are arranged left to right in a single row
-- widths stay equal-split, with at most a one-cell remainder from tmux's
-  geometry
 - splits and kills re-apply the row layout while `even-horizontal` is active on
   the window
 - there is no primary pane, so `promote` and `resize-master` are not implemented
@@ -21,18 +19,10 @@
 | `promote`          | no      | Surfaces a tmux message                          |
 | `resize-master ±N` | no      | Surfaces a tmux message                          |
 
-## Relevant options
-
-No layout-specific options. Set `@mosaic-algorithm` to `even-horizontal` to
-select it globally or per-window. Set `@mosaic-algorithm` to `off` on a window
-to disable mosaic there. Unset the window-local value to fall back to the
-global setting again.
-`@mosaic-orientation`, `@mosaic-mfact`, and `@mosaic-step` are ignored.
-
-## Example use
+## Example config
 
 ```tmux
-set-option -wq @mosaic-algorithm even-horizontal
+bind H set-option -wq @mosaic-algorithm even-horizontal
+bind T run '#{E:@mosaic-exec} toggle'
+bind U set-option -wqu @mosaic-algorithm
 ```
-
-Use stock tmux commands for focus movement, swapping, and zoom.

--- a/docs/layouts/even-vertical.md
+++ b/docs/layouts/even-vertical.md
@@ -6,8 +6,6 @@
 ## Behavior
 
 - panes are stacked top to bottom in a single column
-- heights stay equal-split, with at most a one-cell remainder from tmux's
-  geometry
 - splits and kills re-apply the column layout while `even-vertical` is active
   on the window
 - there is no primary pane, so `promote` and `resize-master` are not implemented
@@ -21,18 +19,10 @@
 | `promote`          | no      | Surfaces a tmux message                        |
 | `resize-master ±N` | no      | Surfaces a tmux message                        |
 
-## Relevant options
-
-No layout-specific options. Set `@mosaic-algorithm` to `even-vertical` to
-select it globally or per-window. Set `@mosaic-algorithm` to `off` on a window
-to disable mosaic there. Unset the window-local value to fall back to the
-global setting again.
-`@mosaic-orientation`, `@mosaic-mfact`, and `@mosaic-step` are ignored.
-
-## Example use
+## Example config
 
 ```tmux
-set-option -wq @mosaic-algorithm even-vertical
+bind V set-option -wq @mosaic-algorithm even-vertical
+bind T run '#{E:@mosaic-exec} toggle'
+bind U set-option -wqu @mosaic-algorithm
 ```
-
-Use stock tmux commands for focus movement, swapping, and zoom.

--- a/docs/layouts/grid.md
+++ b/docs/layouts/grid.md
@@ -6,8 +6,6 @@
 
 - tmux chooses the row and column shape from the current pane count
 - with four panes, the layout becomes a 2x2 grid
-- pane widths and heights stay balanced, with at most a one-cell remainder from
-  tmux's geometry
 - there is no primary pane, so `promote` and `resize-master` are not implemented
 
 ## Supported operations
@@ -19,17 +17,10 @@
 | `promote`          | no      | Surfaces a tmux message                |
 | `resize-master ±N` | no      | Surfaces a tmux message                |
 
-## Relevant options
-
-No layout-specific options. Set `@mosaic-algorithm` to `grid` to select it.
-Set `@mosaic-algorithm` to `off` on a window to disable mosaic there. Unset the
-window-local value to fall back to the global setting again.
-`@mosaic-orientation`, `@mosaic-mfact`, and `@mosaic-step` are ignored.
-
-## Example use
+## Example config
 
 ```tmux
-set-option -wq @mosaic-algorithm grid
+bind G set-option -wq @mosaic-algorithm grid
+bind T run '#{E:@mosaic-exec} toggle'
+bind U set-option -wqu @mosaic-algorithm
 ```
-
-Use stock tmux commands for focus movement, swapping, and zoom.

--- a/docs/layouts/master-stack.md
+++ b/docs/layouts/master-stack.md
@@ -5,16 +5,10 @@
 
 ## Behavior
 
-- `left` uses `main-vertical`
-- `right` uses `main-vertical-mirrored`
-- `top` uses `main-horizontal`
-- `bottom` uses `main-horizontal-mirrored`
-- the master is the first pane in tmux's pane order: pane 1 when
-  `pane-base-index` is 1, or pane 0 when it is 0
+- `left`, `right`, `top`, and `bottom` map to tmux's `main-*` layouts
+- the master is the first pane in tmux's pane order
 - killing the master promotes the stack-top on the next relayout
-- drag-resizing the master updates `@mosaic-mfact`, so the next relayout keeps
-  that size
-- zoomed panes do not rewrite `@mosaic-mfact`
+- drag-resizing the master updates `@mosaic-mfact` for the next relayout
 
 ## Supported operations
 
@@ -33,7 +27,7 @@
 | `@mosaic-mfact`       | window→global | `50`    | Stores the master size as a percent                            |
 | `@mosaic-step`        | global        | `5`     | Used by `resize-master` when you call it without an explicit N |
 
-## Example use
+## Example config
 
 ```tmux
 set-option -gwq @mosaic-algorithm master-stack
@@ -42,17 +36,6 @@ set-option -gwq @mosaic-orientation right
 bind Enter run '#{E:@mosaic-exec} promote'
 bind -r , run '#{E:@mosaic-exec} resize-master -5'
 bind -r . run '#{E:@mosaic-exec} resize-master +5'
-```
-
-Set `@mosaic-algorithm` to `off` on a window to disable mosaic there. Unset the
-window-local value to fall back to the global setting again.
-
-Stock tmux still handles focus movement, swapping through the ring, and zoom:
-
-```tmux
-bind a select-pane -t :.+
-bind f select-pane -t :.-
-bind d swap-pane -D
-bind u swap-pane -U
-bind z resize-pane -Z
+bind T run '#{E:@mosaic-exec} toggle'
+bind U set-option -wqu @mosaic-algorithm
 ```

--- a/docs/layouts/monocle.md
+++ b/docs/layouts/monocle.md
@@ -21,23 +21,12 @@
 | `promote`          | no      | Surfaces a tmux message                          |
 | `resize-master ±N` | no      | Surfaces a tmux message                          |
 
-## Relevant options
-
-No layout-specific options. Set `@mosaic-algorithm` to `monocle` to select it.
-Set `@mosaic-algorithm` to `off` on a window to disable mosaic there. Unset the
-window-local value to fall back to the global setting again.
-`@mosaic-orientation`, `@mosaic-mfact`, and `@mosaic-step` are ignored.
-
-## Example use
+## Example config
 
 ```tmux
-set-option -wq @mosaic-algorithm monocle
-```
-
-Mosaic does not install focus bindings. Use stock tmux commands to choose which
-pane becomes zoomed:
-
-```tmux
+bind Z set-option -wq @mosaic-algorithm monocle
+bind T run '#{E:@mosaic-exec} toggle'
+bind U set-option -wqu @mosaic-algorithm
 bind n select-pane -t :.+
 bind p select-pane -t :.-
 ```


### PR DESCRIPTION
## Problem

The docs described the layout model, but they still did not show a realistic tmux setup for someone using a global default plus a few per-window layout switches.

## Solution

Rewrite the README around that actual workflow, and tighten the per-layout docs so each one shows a short tmux.conf example for wiring that layout into a real setup.