### PR TITLE
docs: tighten quick start and layout overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,25 +11,12 @@
 
 TPM, manual, and nix setup live in [INSTALLATION.md](INSTALLATION.md).
 
-## [Layouts](docs/layouts/)
-
-- [`master-stack`](docs/layouts/master-stack.md#master-stack) — one master pane
-  plus equal-split stack
-- [`even-vertical`](docs/layouts/even-vertical.md#even-vertical) — equal-height
-  column
-- [`even-horizontal`](docs/layouts/even-horizontal.md#even-horizontal) —
-  equal-width row
-- [`grid`](docs/layouts/grid.md#grid) — tmux `tiled`
-- [`monocle`](docs/layouts/monocle.md#monocle) — keep the focused pane zoomed
-
 ## Quick Start
 
-tmux-mosaic does _not_ bundle keymaps. A realistic setup is to pick a global
-default, bind the operations you use for that default, and bind a few
-per-window layout switches.
-
-For example, use `master-stack` everywhere by default, then swap one window to
-`grid` when it fits better:
+tmux-mosaic does _not_ bundle keymaps. Say you like `master-stack` everywhere
+by default, but one window looks better as `grid`. Set the global default, bind
+the `master-stack` ops you care about, and add a few per-window layout
+switches:
 
 ```tmux
 set-option -gwq @mosaic-algorithm master-stack
@@ -44,12 +31,21 @@ bind Z     set-option -wq @mosaic-algorithm monocle
 bind U     set-option -wqu @mosaic-algorithm
 ```
 
-Most windows now inherit `master-stack`. When one window wants `grid`, press
-`G` on that window. Press `U` to clear the local override and go back to the
-global default.
+Most windows now inherit `master-stack`. If one window wants `grid`, hit `G`
+there. If you want to go back to the global default, hit `U`.
 
-Each layout page has a short tmux.conf example for wiring that layout into a
-real setup.
+See [Layouts](docs/layouts/) for the layout pages and global options.
+
+## [Layouts](docs/layouts/)
+
+- [`master-stack`](docs/layouts/master-stack.md#master-stack) — one master pane
+  plus equal-split stack
+- [`even-vertical`](docs/layouts/even-vertical.md#even-vertical) — equal-height
+  column
+- [`even-horizontal`](docs/layouts/even-horizontal.md#even-horizontal) —
+  equal-width row
+- [`grid`](docs/layouts/grid.md#grid) — tmux `tiled`
+- [`monocle`](docs/layouts/monocle.md#monocle) — keep the focused pane zoomed
 
 ## Acknowledgements
 

--- a/docs/layouts/README.md
+++ b/docs/layouts/README.md
@@ -1,38 +1,17 @@
 # Layouts
 
-Set a global layout default for all windows with:
+Layouts are the pane arrangements Mosaic can apply. The table below lists the
+available layouts, the tmux primitive behind each one, and which operations
+they support.
 
-```tmux
-set-option -gwq @mosaic-algorithm master-stack
-```
+## Global options
 
-Override just the current window with:
-
-```tmux
-set-option -wq @mosaic-algorithm grid
-```
-
-Disable mosaic on just the current window with:
-
-```tmux
-set-option -wq @mosaic-algorithm off
-```
-
-Unset the window-local value to fall back to the global setting again:
-
-```tmux
-set-option -wqu @mosaic-algorithm
-```
-
-Each layout page includes a short tmux.conf example for using that layout in a
-real setup.
-
-All layouts support `toggle` and `relayout`. Unsupported operations surface a
-tmux message instead of failing hard. `toggle` disables the current window; if
-the window is locally `off` and a global layout is configured, `toggle`
-re-enables the global setting. Mosaic only relayouts windows whose effective
-`@mosaic-algorithm` resolves to a layout and that have more than one pane.
-Invalid algorithm names fail when an operation tries to load them.
+| Option                | Default | Effect                                              |
+| --------------------- | ------- | --------------------------------------------------- |
+| `@mosaic-algorithm`   | unset   | Global default layout for windows without a local override |
+| `@mosaic-orientation` | `left`  | For `master-stack`: `left`, `right`, `top`, or `bottom` |
+| `@mosaic-mfact`       | `50`    | For `master-stack`: master size as a percent        |
+| `@mosaic-step`        | `5`     | Default `resize-master` step                        |
 
 | Layout            | Backing tmux layout | `promote` | `resize-master` | Notes                                     | Page                                  |
 | ----------------- | ------------------- | --------- | --------------- | ----------------------------------------- | ------------------------------------- |


### PR DESCRIPTION
## Problem

The README and `docs/layouts/README.md` were still carrying extra structure and explanation that got in the way of the actual docs flow.

## Solution

Move the README to installation -> quick start -> layouts, make the quick start read like a workflow, and reduce the layouts index to just the layouts overview and global options.
