### PR TITLE
docs: refine quick start and simplify layout overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ bind U     set-option -wqu @mosaic-algorithm
 Most windows now inherit `master-stack`. Hit `G` in the one window that wants
 `grid`. Hit `U` to go back to the global default.
 
-See [Layouts](docs/layouts/) for the layout pages and global options.
+See [Layouts](docs/layouts/) for per-layout behavior and examples.
 
 ## [Layouts](docs/layouts/)
 

--- a/README.md
+++ b/README.md
@@ -13,26 +13,40 @@ TPM, manual, and nix setup live in [INSTALLATION.md](INSTALLATION.md).
 
 ## Quick Start
 
-tmux-mosaic does _not_ bundle keymaps. Say you like `master-stack` everywhere
-by default, but one window looks better as `grid`. Set the global default, bind
-the `master-stack` ops you care about, and add a few per-window layout
-switches:
+tmux-mosaic does _not_ bundle keymaps.
+
+Start by making `master-stack` the global default:
 
 ```tmux
 set-option -gwq @mosaic-algorithm master-stack
+```
+
+Then bind the `master-stack` operations you care about:
+
+```tmux
 bind Enter run '#{E:@mosaic-exec} promote'
 bind -r ,  run '#{E:@mosaic-exec} resize-master -5'
 bind -r .  run '#{E:@mosaic-exec} resize-master +5'
 bind T     run '#{E:@mosaic-exec} toggle'
+```
+
+If one window looks better as `grid`, switch just that window:
+
+```tmux
 bind G     set-option -wq @mosaic-algorithm grid
+```
+
+Keep a few other layout switches nearby if you want them:
+
+```tmux
 bind V     set-option -wq @mosaic-algorithm even-vertical
 bind H     set-option -wq @mosaic-algorithm even-horizontal
 bind Z     set-option -wq @mosaic-algorithm monocle
 bind U     set-option -wqu @mosaic-algorithm
 ```
 
-Most windows now inherit `master-stack`. If one window wants `grid`, hit `G`
-there. If you want to go back to the global default, hit `U`.
+Most windows now inherit `master-stack`. Hit `G` in the one window that wants
+`grid`. Hit `U` to go back to the global default.
 
 See [Layouts](docs/layouts/) for the layout pages and global options.
 

--- a/docs/layouts/README.md
+++ b/docs/layouts/README.md
@@ -6,12 +6,15 @@ they support.
 
 ## Global options
 
-| Option                | Default | Effect                                              |
-| --------------------- | ------- | --------------------------------------------------- |
-| `@mosaic-algorithm`   | unset   | Global default layout for windows without a local override |
-| `@mosaic-orientation` | `left`  | For `master-stack`: `left`, `right`, `top`, or `bottom` |
-| `@mosaic-mfact`       | `50`    | For `master-stack`: master size as a percent        |
-| `@mosaic-step`        | `5`     | Default `resize-master` step                        |
+| Option              | Default | Effect                                              |
+| ------------------- | ------- | --------------------------------------------------- |
+| `@mosaic-algorithm` | unset   | Global default layout for windows without a local override |
+| `@mosaic-step`      | `5`     | Default `resize-master` step                        |
+
+`master-stack` also uses `@mosaic-orientation` and `@mosaic-mfact`; see the
+[`master-stack`](master-stack.md) page for those.
+
+## Available layouts
 
 | Layout            | Backing tmux layout | `promote` | `resize-master` | Notes                                     | Page                                  |
 | ----------------- | ------------------- | --------- | --------------- | ----------------------------------------- | ------------------------------------- |

--- a/docs/layouts/README.md
+++ b/docs/layouts/README.md
@@ -4,18 +4,6 @@ Layouts are the pane arrangements Mosaic can apply. The table below lists the
 available layouts, the tmux primitive behind each one, and which operations
 they support.
 
-## Global options
-
-| Option              | Default | Effect                                              |
-| ------------------- | ------- | --------------------------------------------------- |
-| `@mosaic-algorithm` | unset   | Global default layout for windows without a local override |
-| `@mosaic-step`      | `5`     | Default `resize-master` step                        |
-
-`master-stack` also uses `@mosaic-orientation` and `@mosaic-mfact`; see the
-[`master-stack`](master-stack.md) page for those.
-
-## Available layouts
-
 | Layout            | Backing tmux layout | `promote` | `resize-master` | Notes                                     | Page                                  |
 | ----------------- | ------------------- | --------- | --------------- | ----------------------------------------- | ------------------------------------- |
 | `master-stack`    | `main-*` family     | yes       | yes             | One master pane plus equal-split stack    | [master-stack](master-stack.md)       |


### PR DESCRIPTION
## Problem

The README quick start still read like a dense config dump, and `docs/layouts/README.md` was still carrying extra reference structure that did not belong there.

## Solution

Rewrite the quick start as a smaller interactive setup and reduce the layouts index to just the layouts table.
