### PR TITLE
feat(option): @mosaic-nmaster

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,15 +103,19 @@ bind U     set-option -wqu @mosaic-algorithm
 Layouts are the pane arrangements Mosaic can apply. The following are provided:
 
 <details>
-<summary><code>master-stack</code> — one primary pane plus equal-split stack</summary>
+<summary><code>master-stack</code> — one or more master panes plus equal-split stack</summary>
 
 ### Behavior
 
-This uses tmux's `main-*` layouts and keeps the master as the first pane in
-tmux's pane order. `@mosaic-orientation` chooses whether the master sits on the
-left, right, top, or bottom. If you kill the master, the stack-top becomes the
-new master on the next relayout, and if you drag-resize it, Mosaic syncs that
-size back into `@mosaic-mfact`.
+This keeps the first `@mosaic-nmaster` panes in the master area and the rest in
+an equal-split stack. `@mosaic-orientation` chooses whether the master area
+sits on the left, right, top, or bottom. `resize-master` changes the size of
+the whole master area, not individual master panes. If you kill inside the
+master area, the next pane in tmux's pane order fills the gap on the next
+relayout, and if you drag-resize the master/stack boundary, Mosaic syncs that
+size back into `@mosaic-mfact`. If `@mosaic-nmaster` is at least the pane
+count, all panes become masters and Mosaic falls back to an equal split in the
+chosen axis.
 
 ### Preview
 
@@ -123,8 +127,8 @@ size back into `@mosaic-mfact`.
 | ------------------------------ | ------------------------------------------------------------------------- |
 | `toggle`                       | Turn `master-stack` off on the current window.                            |
 | `relayout`                     | Re-apply the current orientation and `@mosaic-mfact`.                     |
-| `promote`                      | Focused stack pane becomes master. On master, swap with stack-top.        |
-| `resize-master ±N`             | Change `@mosaic-mfact` for the current window, clamped to 5–95.           |
+| `promote`                      | Focused pane becomes the primary master. On the primary master, rotate the next pane forward. |
+| `resize-master ±N`             | Change the whole master-region size for the current window, clamped to 5–95. |
 | `select-pane -t :.-` (builtin) | Focus the previous pane in stack order.                                   |
 | `select-pane -t :.+` (builtin) | Focus the next pane in stack order.                                       |
 | `swap-pane -U` (builtin)       | Move the current pane up the stack.                                       |
@@ -138,6 +142,7 @@ size back into `@mosaic-mfact`.
 | Option                | Scope         | Default | Effect                                                         |
 | --------------------- | ------------- | ------- | -------------------------------------------------------------- |
 | `@mosaic-orientation` | window→global | `left`  | Chooses `left`, `right`, `top`, or `bottom`                    |
+| `@mosaic-nmaster`     | window→global | `1`     | Keeps the first N panes in the master area                     |
 | `@mosaic-mfact`       | window→global | `50`    | Stores the master size as a percent                            |
 | `@mosaic-step`        | global        | `5`     | Used by `resize-master` when you call it without an explicit N |
 
@@ -146,6 +151,7 @@ size back into `@mosaic-mfact`.
 ```tmux
 set-option -gwq @mosaic-algorithm master-stack
 set-option -gwq @mosaic-orientation right
+set-option -gwq @mosaic-nmaster 2
 
 bind Enter run '#{E:@mosaic-exec} promote'
 bind -r , run '#{E:@mosaic-exec} resize-master -5'

--- a/scripts/algorithms/master-stack.sh
+++ b/scripts/algorithms/master-stack.sh
@@ -34,6 +34,20 @@ algo_main_option_for() {
   esac
 }
 
+algo_full_layout_for() {
+  case "$1" in
+  left | right) echo "even-vertical" ;;
+  top | bottom) echo "even-horizontal" ;;
+  esac
+}
+
+algo_join_flag_for() {
+  case "$1" in
+  left | right) echo "-v" ;;
+  top | bottom) echo "-h" ;;
+  esac
+}
+
 algo_apply_layout() {
   local win="$1" orientation="$2" mfact="$3"
   tmux set-window-option -t "$win" "$(algo_main_option_for "$orientation")" "${mfact}%" 2>/dev/null || true
@@ -58,17 +72,43 @@ algo_swap_keep_focus() {
   tmux select-pane -t "$pid"
 }
 
+algo_bubble_keep_focus() {
+  local from="$1" to="$2"
+  while [[ "$from" -gt "$to" ]]; do
+    algo_swap_keep_focus -s ":.$from" -t ":.$((from - 1))"
+    from=$((from - 1))
+  done
+}
+
+algo_join_extra_masters() {
+  local win="$1" orientation="$2" nmaster="$3" n="$4" pbase="$5"
+  local flag idx
+  flag=$(algo_join_flag_for "$orientation")
+  for ((idx = pbase + 1; idx < pbase + nmaster; idx++)); do
+    tmux join-pane -d "$flag" -s "$win.$idx" -t "$win.$((idx - 1))" 2>/dev/null || true
+  done
+  [[ "$nmaster" -gt 2 ]] && tmux select-layout -t "$win.$pbase" -E 2>/dev/null || true
+  [[ $((n - nmaster)) -gt 1 ]] && tmux select-layout -t "$win.$((pbase + nmaster))" -E 2>/dev/null || true
+}
+
 algo_relayout() {
-  local win n mfact orientation
+  local win n mfact orientation nmaster pbase
   win=$(mosaic_resolve_window "${1:-}")
   n=$(mosaic_window_pane_count "$win")
   mosaic_can_relayout_window "$win" "$n" || return 0
   mfact=$(algo_mfact_for "$win")
   orientation=$(algo_orientation_for "$win")
+  nmaster=$(mosaic_effective_nmaster "$win" "$n")
+  pbase=$(algo_pane_base)
 
   algo_apply_layout "$win" "$orientation" "$mfact"
+  if [[ "$nmaster" -ge "$n" ]]; then
+    tmux select-layout -t "$win" "$(algo_full_layout_for "$orientation")" 2>/dev/null || true
+  elif [[ "$nmaster" -gt 1 ]]; then
+    algo_join_extra_masters "$win" "$orientation" "$nmaster" "$n" "$pbase"
+  fi
 
-  mosaic_log "relayout: win=$win n=$n orientation=$orientation mfact=$mfact"
+  mosaic_log "relayout: win=$win n=$n orientation=$orientation nmaster=$nmaster mfact=$mfact"
 }
 
 algo_toggle() { mosaic_toggle_window algo_relayout; }
@@ -84,7 +124,7 @@ algo_promote() {
   if [[ "$idx" -eq "$pbase" ]]; then
     algo_swap_keep_focus -s ":.$pbase" -t ":.$((pbase + 1))"
   else
-    algo_swap_keep_focus -s ":.$idx" -t ":.$pbase"
+    algo_bubble_keep_focus "$idx" "$pbase"
   fi
   algo_relayout
 }
@@ -109,9 +149,11 @@ algo_sync_state() {
   mosaic_enabled "$win" || return 0
   [[ "$(mosaic_window_zoomed "$win")" == "1" ]] && return 0
 
-  local n
+  local n nmaster
   n=$(mosaic_window_pane_count "$win")
   [[ "$n" -le 1 ]] && return 0
+  nmaster=$(mosaic_effective_nmaster "$win" "$n")
+  [[ "$nmaster" -ge "$n" ]] && return 0
 
   local pbase pane_size window_size pct orientation
   orientation=$(algo_orientation_for "$win")

--- a/scripts/defaults.sh
+++ b/scripts/defaults.sh
@@ -2,6 +2,7 @@
 
 mosaic_set_defaults() {
   tmux set-option -gwq "@mosaic-orientation" "left"
+  tmux set-option -gwq "@mosaic-nmaster" "1"
   tmux set-option -gq "@mosaic-mfact" "50"
   tmux set-option -gq "@mosaic-step" "5"
   tmux set-option -gq "@mosaic-debug" "0"

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -99,6 +99,24 @@ mosaic_window_zoomed() {
   tmux display-message -p -t "$(mosaic_resolve_window "${1:-}")" '#{window_zoomed_flag}'
 }
 
+mosaic_nmaster_for() {
+  local target="${1:-}" val
+  val=$(mosaic_get_w "@mosaic-nmaster" "1" "$target")
+  [[ "$val" =~ ^[1-9][0-9]*$ ]] || {
+    mosaic_log "nmaster: invalid=$val target=$target defaulting=1"
+    val=1
+  }
+  printf '%s\n' "$val"
+}
+
+mosaic_effective_nmaster() {
+  local target="${1:-}" n="${2:-}" val
+  [[ -n "$n" ]] || n=$(mosaic_window_pane_count "$target")
+  val=$(mosaic_nmaster_for "$target")
+  [[ "$val" -gt "$n" ]] && val=$n
+  printf '%s\n' "$val"
+}
+
 mosaic_first_client() {
   tmux list-clients -F '#{client_name}' 2>/dev/null | head -n1
 }

--- a/tests/integration/master_stack.bats
+++ b/tests/integration/master_stack.bats
@@ -15,6 +15,10 @@ set_orientation() {
   mosaic_t set-option -wq -t "${1:-t:1}" "@mosaic-orientation" "${2:?orientation required}"
 }
 
+set_nmaster() {
+  mosaic_t set-option -wq -t "${1:-t:1}" "@mosaic-nmaster" "${2:?nmaster required}"
+}
+
 pane_field() {
   mosaic_t list-panes -t "${1:-t:1}" -F '#{pane_index} #{pane_left} #{pane_top} #{pane_width} #{pane_height}' |
     awk -v idx="${2:?pane index required}" -v field="${3:?field required}" '$1 == idx { print $field }'
@@ -66,6 +70,10 @@ assert_orientation_layout() {
   run mosaic_t show-option -gwqv @mosaic-orientation
   [ "$status" -eq 0 ]
   [ "$output" = "left" ]
+
+  run mosaic_t show-option -gwqv @mosaic-nmaster
+  [ "$status" -eq 0 ]
+  [ "$output" = "1" ]
 }
 
 @test "plugin load: hooks are registered" {
@@ -118,6 +126,38 @@ assert_orientation_layout() {
   [ "${diff#-}" -le 1 ]
 }
 
+@test "nmaster 3: first three panes share the master area" {
+  set_nmaster t:1 3
+  for _ in 1 2 3 4; do mosaic_split; done
+
+  [ "$(pane_field t:1 1 2)" = "0" ]
+  [ "$(pane_field t:1 2 2)" = "0" ]
+  [ "$(pane_field t:1 3 2)" = "0" ]
+  [ "$(pane_field t:1 4 2)" -gt 0 ]
+
+  pane1_h=$(pane_field t:1 1 5)
+  pane2_h=$(pane_field t:1 2 5)
+  pane3_h=$(pane_field t:1 3 5)
+  diff12=$((pane1_h - pane2_h))
+  diff23=$((pane2_h - pane3_h))
+  [ "${diff12#-}" -le 1 ]
+  [ "${diff23#-}" -le 1 ]
+}
+
+@test "nmaster 2 and right orientation keep both masters on the right" {
+  set_nmaster t:1 2
+  set_orientation t:1 right
+  for _ in 1 2 3; do mosaic_split; done
+
+  [ "$(pane_field t:1 1 2)" -gt 0 ]
+  [ "$(pane_field t:1 2 2)" -gt 0 ]
+  [ "$(pane_field t:1 3 2)" = "0" ]
+
+  pane1_w=$(pane_field t:1 1 4)
+  pane2_w=$(pane_field t:1 2 4)
+  [ "$pane1_w" = "$pane2_w" ]
+}
+
 @test "promote from stack: focused pane becomes master" {
   for _ in 1 2 3; do mosaic_split; done
   mosaic_t select-pane -t t:1.3
@@ -137,6 +177,35 @@ assert_orientation_layout() {
   mosaic_op promote
   [ "$(mosaic_pane_id_at t:1.1)" = "$stack_top_pid" ]
   [ "$(mosaic_pane_id_at t:1.2)" = "$master_pid" ]
+}
+
+@test "promote from stack with nmaster 2 bubbles the focused pane to primary" {
+  set_nmaster t:1 2
+  for _ in 1 2 3; do mosaic_split; done
+  master1_pid=$(mosaic_pane_id_at t:1.1)
+  master2_pid=$(mosaic_pane_id_at t:1.2)
+  chosen_pid=$(mosaic_pane_id_at t:1.4)
+  mosaic_t select-pane -t t:1.4
+
+  mosaic_op promote
+
+  [ "$(mosaic_pane_index)" = "1" ]
+  [ "$(mosaic_pane_id_at t:1.1)" = "$chosen_pid" ]
+  [ "$(mosaic_pane_id_at t:1.2)" = "$master1_pid" ]
+  [ "$(mosaic_pane_id_at t:1.3)" = "$master2_pid" ]
+}
+
+@test "promote on primary master with nmaster 2 rotates the next master forward" {
+  set_nmaster t:1 2
+  for _ in 1 2 3; do mosaic_split; done
+  master1_pid=$(mosaic_pane_id_at t:1.1)
+  master2_pid=$(mosaic_pane_id_at t:1.2)
+  mosaic_t select-pane -t t:1.1
+
+  mosaic_op promote
+
+  [ "$(mosaic_pane_id_at t:1.1)" = "$master2_pid" ]
+  [ "$(mosaic_pane_id_at t:1.2)" = "$master1_pid" ]
 }
 
 @test "resize-master adjusts mfact (window-scoped) and clamps" {
@@ -164,6 +233,22 @@ assert_orientation_layout() {
 
   [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
   [ "$(mosaic_t show-option -wqv -t t:1 main-pane-height)" = "60%" ]
+}
+
+@test "resize-master with nmaster 2 resizes the whole master region" {
+  set_nmaster t:1 2
+  for _ in 1 2 3; do mosaic_split; done
+
+  mosaic_op resize-master +10
+
+  [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
+  pane1_w=$(pane_field t:1 1 4)
+  pane2_w=$(pane_field t:1 2 4)
+  pane3_w=$(pane_field t:1 3 4)
+  [ "$pane1_w" = "$pane2_w" ]
+  [ "$pane1_w" -ge 118 ]
+  [ "$pane1_w" -le 121 ]
+  [ "$pane1_w" -gt "$pane3_w" ]
 }
 
 @test "resize-master on two windows is independent" {
@@ -330,6 +415,21 @@ assert_orientation_layout() {
   pane_w=$(mosaic_t list-panes -t t:1 -F '#{pane_index} #{pane_width}' | awk '$1==1{print $2}')
   [ "$pane_w" -ge 158 ]
   [ "$pane_w" -le 161 ]
+}
+
+@test "drag-resize with nmaster 2 syncs mfact from the master region" {
+  set_nmaster t:1 2
+  for _ in 1 2; do mosaic_split; done
+  mosaic_t resize-pane -t t:1.1 -x 120
+  sleep 0.2
+  [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
+
+  mosaic_split
+  pane1_w=$(pane_field t:1 1 4)
+  pane2_w=$(pane_field t:1 2 4)
+  [ "$pane1_w" = "$pane2_w" ]
+  [ "$pane1_w" -ge 118 ]
+  [ "$pane1_w" -le 121 ]
 }
 
 @test "drag-resize: zoomed pane does not poison mfact" {


### PR DESCRIPTION
## Problem

`master-stack` only supported a single master pane, so issue #50 could not expose a shared `@mosaic-nmaster` option or define multi-master `promote` and `resize-master` behavior.

## Solution

Add `@mosaic-nmaster` as a window→global option with a default of `1`, teach `master-stack` to expand the master region with tmux-native `join-pane` plus subtree rebalancing, update `promote` and drag-resize syncing for multi-master behavior, and cover the new semantics in integration tests and the README. Closes #50.