### PR TITLE
feat(algorithm): bottom-stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,54 @@ run-shell ${XDG_DATA_HOME:-$HOME/.local/share}/tmux/plugins/tmux-mosaic/mosaic.t
 </details>
 
 <details>
+<summary><code>bottom-stack</code> — master above, stack below</summary>
+
+### Behavior
+
+This is the fixed top-master variant of `master-stack`. It keeps the first
+`@mosaic-nmaster` panes in a master strip across the top and the rest in an
+equal-width stack below. `resize-master` changes the height of the whole master
+region, `promote` follows the same primary-master behavior as `master-stack`,
+and drag-resizing the master boundary syncs back into `@mosaic-mfact`.
+
+### Core actions
+
+| Command                        | Behavior                                                                        |
+| ------------------------------ | ------------------------------------------------------------------------------- |
+| `toggle`                       | Turn `bottom-stack` off on the current window.                                  |
+| `relayout`                     | Re-apply the top-master / bottom-stack split and `@mosaic-mfact`.               |
+| `promote`                      | Focused pane becomes the primary master. On the primary master, rotate the next pane forward. |
+| `resize-master ±N`             | Change the whole master-region height for the current window, clamped to 5–95.  |
+| `select-pane -t :.-` (builtin) | Focus the previous pane in stack order.                                         |
+| `select-pane -t :.+` (builtin) | Focus the next pane in stack order.                                             |
+| `swap-pane -U` (builtin)       | Move the current pane up the stack.                                             |
+| `swap-pane -D` (builtin)       | Move the current pane down the stack.                                           |
+| `split-window` (builtin)       | Add a pane and rebalance the top master region plus bottom stack.               |
+| `kill-pane` (builtin)          | Remove a pane and rebalance; killing in the master area pulls the next pane up. |
+| `resize-pane` (builtin)        | Resize the master live, then sync the new height back into `@mosaic-mfact`.     |
+
+### Relevant options
+
+| Option            | Scope         | Default | Effect                                              |
+| ----------------- | ------------- | ------- | --------------------------------------------------- |
+| `@mosaic-nmaster` | window→global | `1`     | Keeps the first N panes in the top master area      |
+| `@mosaic-mfact`   | window→global | `50`    | Stores the master-region height as a percent        |
+| `@mosaic-step`    | global        | `5`     | Used by `resize-master` when you call it without N  |
+
+### Example config
+
+```tmux
+bind B set-option -wq @mosaic-algorithm bottom-stack
+bind Enter run '#{E:@mosaic-exec} promote'
+bind -r , run '#{E:@mosaic-exec} resize-master -5'
+bind -r . run '#{E:@mosaic-exec} resize-master +5'
+bind T run '#{E:@mosaic-exec} toggle'
+bind U set-option -wqu @mosaic-algorithm
+```
+
+</details>
+
+<details>
 <summary>Nix</summary>
 
 ### Nix

--- a/scripts/algorithms/bottom-stack.sh
+++ b/scripts/algorithms/bottom-stack.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+
+algo_pane_count() { tmux display-message -p '#{window_panes}'; }
+algo_pane_index() { tmux display-message -p '#{pane_index}'; }
+algo_pane_base() { tmux display-message -p '#{e|+|:0,#{?pane-base-index,#{pane-base-index},0}}'; }
+
+algo_apply_layout() {
+  local win="$1" mfact="$2"
+  tmux set-window-option -t "$win" main-pane-height "${mfact}%" 2>/dev/null || true
+  tmux select-layout -t "$win" main-horizontal 2>/dev/null || true
+}
+
+algo_mfact_for() {
+  local win="$1"
+  local val
+  val=$(tmux show-option -wqv -t "$win" "@mosaic-mfact" 2>/dev/null)
+  [[ -n "$val" ]] && {
+    echo "$val"
+    return
+  }
+  mosaic_get "@mosaic-mfact" "50"
+}
+
+algo_swap_keep_focus() {
+  local pid
+  pid=$(tmux display-message -p '#{pane_id}')
+  tmux swap-pane "$@"
+  tmux select-pane -t "$pid"
+}
+
+algo_bubble_keep_focus() {
+  local from="$1" to="$2"
+  while [[ "$from" -gt "$to" ]]; do
+    algo_swap_keep_focus -s ":.$from" -t ":.$((from - 1))"
+    from=$((from - 1))
+  done
+}
+
+algo_join_extra_masters() {
+  local win="$1" nmaster="$2" n="$3" pbase="$4"
+  local idx
+  for ((idx = pbase + 1; idx < pbase + nmaster; idx++)); do
+    tmux join-pane -d -h -s "$win.$idx" -t "$win.$((idx - 1))" 2>/dev/null || true
+  done
+  [[ "$nmaster" -gt 2 ]] && tmux select-layout -t "$win.$pbase" -E 2>/dev/null || true
+  [[ $((n - nmaster)) -gt 1 ]] && tmux select-layout -t "$win.$((pbase + nmaster))" -E 2>/dev/null || true
+}
+
+algo_relayout() {
+  local win n mfact nmaster pbase
+  win=$(mosaic_resolve_window "${1:-}")
+  n=$(mosaic_window_pane_count "$win")
+  mosaic_can_relayout_window "$win" "$n" || return 0
+  mfact=$(algo_mfact_for "$win")
+  nmaster=$(mosaic_effective_nmaster "$win" "$n")
+  pbase=$(algo_pane_base)
+
+  algo_apply_layout "$win" "$mfact"
+  if [[ "$nmaster" -ge "$n" ]]; then
+    tmux select-layout -t "$win" even-horizontal 2>/dev/null || true
+  elif [[ "$nmaster" -gt 1 ]]; then
+    algo_join_extra_masters "$win" "$nmaster" "$n" "$pbase"
+  fi
+
+  mosaic_log "relayout: win=$win n=$n layout=bottom-stack nmaster=$nmaster mfact=$mfact"
+}
+
+algo_toggle() { mosaic_toggle_window algo_relayout; }
+
+algo_promote() {
+  local idx n pbase
+  idx=$(algo_pane_index)
+  n=$(algo_pane_count)
+  pbase=$(algo_pane_base)
+
+  [[ "$n" -le 1 ]] && return 0
+
+  if [[ "$idx" -eq "$pbase" ]]; then
+    algo_swap_keep_focus -s ":.$pbase" -t ":.$((pbase + 1))"
+  else
+    algo_bubble_keep_focus "$idx" "$pbase"
+  fi
+  algo_relayout
+}
+
+algo_resize_master() {
+  local delta="${1:-}"
+  if [[ -z "$delta" ]]; then
+    delta=$(mosaic_get "@mosaic-step" "5")
+  fi
+  local win cur new
+  win=$(mosaic_current_window)
+  cur=$(algo_mfact_for "$win")
+  new=$((cur + delta))
+  [[ "$new" -lt 5 ]] && new=5
+  [[ "$new" -gt 95 ]] && new=95
+  tmux set-option -wq -t "$win" "@mosaic-mfact" "$new"
+  algo_relayout "$win"
+}
+
+algo_sync_state() {
+  local win="$1"
+  mosaic_enabled "$win" || return 0
+  [[ "$(mosaic_window_zoomed "$win")" == "1" ]] && return 0
+
+  local n nmaster
+  n=$(mosaic_window_pane_count "$win")
+  [[ "$n" -le 1 ]] && return 0
+  nmaster=$(mosaic_effective_nmaster "$win" "$n")
+  [[ "$nmaster" -ge "$n" ]] && return 0
+
+  local pbase pane_size window_size pct
+  pbase=$(algo_pane_base)
+  pane_size=$(tmux display-message -p -t "$win.$pbase" '#{pane_height}' 2>/dev/null)
+  window_size=$(tmux display-message -p -t "$win" '#{window_height}' 2>/dev/null)
+  [[ -z "$pane_size" ]] && return 0
+  [[ -z "$window_size" || "$window_size" -le 0 ]] && return 0
+
+  pct=$((pane_size * 100 / window_size))
+  [[ "$pct" -lt 5 ]] && pct=5
+  [[ "$pct" -gt 95 ]] && pct=95
+
+  tmux set-option -wq -t "$win" "@mosaic-mfact" "$pct"
+  mosaic_log "sync-state: win=$win layout=bottom-stack pane_size=$pane_size window_size=$window_size pct=$pct"
+}

--- a/tests/integration/bottom_stack.bats
+++ b/tests/integration/bottom_stack.bats
@@ -1,0 +1,101 @@
+#!/usr/bin/env bats
+
+load '../helpers.bash'
+
+setup() {
+  mosaic_setup_server
+  mosaic_use_algorithm bottom-stack
+}
+
+teardown() {
+  mosaic_teardown_server
+}
+
+set_nmaster() {
+  mosaic_t set-option -wq -t "${1:-t:1}" "@mosaic-nmaster" "${2:?nmaster required}"
+}
+
+pane_field() {
+  mosaic_t list-panes -t "${1:-t:1}" -F '#{pane_index} #{pane_left} #{pane_top} #{pane_width} #{pane_height}' |
+    awk -v idx="${2:?pane index required}" -v field="${3:?field required}" '$1 == idx { print $field }'
+}
+
+@test "bottom-stack: 4 panes keep the master on top and the stack below" {
+  for _ in 1 2 3; do mosaic_split; done
+  [ "$(mosaic_pane_count)" = "4" ]
+
+  layout=$(mosaic_layout)
+  [[ "$layout" == *"["* ]]
+  [[ "$layout" == *"{"* ]]
+
+  [ "$(pane_field t:1 1 3)" = "0" ]
+  [ "$(pane_field t:1 2 3)" -gt 0 ]
+  [ "$(pane_field t:1 1 4)" -gt "$(pane_field t:1 2 4)" ]
+
+  pane2_w=$(pane_field t:1 2 4)
+  pane3_w=$(pane_field t:1 3 4)
+  diff=$((pane2_w - pane3_w))
+  [ "${diff#-}" -le 1 ]
+}
+
+@test "bottom-stack: nmaster 2 keeps both masters in the top row" {
+  set_nmaster t:1 2
+  for _ in 1 2 3; do mosaic_split; done
+
+  [ "$(pane_field t:1 1 3)" = "0" ]
+  [ "$(pane_field t:1 2 3)" = "0" ]
+  [ "$(pane_field t:1 3 3)" -gt 0 ]
+
+  pane1_w=$(pane_field t:1 1 4)
+  pane2_w=$(pane_field t:1 2 4)
+  diff=$((pane1_w - pane2_w))
+  [ "${diff#-}" -le 1 ]
+}
+
+@test "bottom-stack: promote from stack makes the focused pane primary master" {
+  for _ in 1 2 3; do mosaic_split; done
+  mosaic_t select-pane -t t:1.3
+  pid=$(mosaic_t display-message -p -t t:1 '#{pane_id}')
+
+  mosaic_op promote
+
+  [ "$(mosaic_pane_index)" = "1" ]
+  [ "$(mosaic_t display-message -p -t t:1 '#{pane_id}')" = "$pid" ]
+}
+
+@test "bottom-stack: resize-master writes main-pane-height" {
+  for _ in 1 2 3; do mosaic_split; done
+
+  mosaic_op resize-master +10
+
+  [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
+  [ "$(mosaic_t show-option -wqv -t t:1 main-pane-height)" = "60%" ]
+}
+
+@test "bottom-stack: kill rebalances the bottom stack" {
+  for _ in 1 2 3 4; do mosaic_split; done
+  [ "$(mosaic_pane_count)" = "5" ]
+
+  mosaic_t kill-pane -t t:1.3
+  sleep 0.2
+
+  [ "$(mosaic_pane_count)" = "4" ]
+  pane2_w=$(pane_field t:1 2 4)
+  pane3_w=$(pane_field t:1 3 4)
+  diff=$((pane2_w - pane3_w))
+  [ "${diff#-}" -le 1 ]
+}
+
+@test "bottom-stack: drag-resize syncs mfact from the master height" {
+  mosaic_split
+  mosaic_t resize-pane -t t:1.1 -y 30
+  sleep 0.2
+  mfact=$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)
+  [ "$mfact" -ge 55 ]
+  [ "$mfact" -le 65 ]
+
+  mosaic_split
+  pane_h=$(pane_field t:1 1 5)
+  [ "$pane_h" -ge 28 ]
+  [ "$pane_h" -le 31 ]
+}


### PR DESCRIPTION
## Problem

Mosaic has `master-stack`, but it does not have the top-master / bottom-stack sibling from #46. That leaves a very common dwm-style layout missing from the current set.

## Solution

Add `bottom-stack` as the fixed top-master variant of the shared master/stack behavior, including `@mosaic-nmaster`, `promote`, `resize-master`, and drag-resize syncing. Cover it with integration tests and document the layout in the README. The deferred screenshot and README preview follow-up is tracked in #53. Closes #46.