### PR TITLE
feat(algorithm): add three-column

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,55 +51,6 @@ run-shell ${XDG_DATA_HOME:-$HOME/.local/share}/tmux/plugins/tmux-mosaic/mosaic.t
 </details>
 
 <details>
-<summary><code>centered-master</code> — center master with side stacks</summary>
-
-### Behavior
-
-This keeps `@mosaic-nmaster` panes in a center column and splits the remaining
-panes into left and right stacks. If there is only one stack pane, it falls
-back to master plus right stack; otherwise the master stays centered, and an odd
-extra stack pane goes to the right. `resize-master` changes the width of the
-whole center region, and drag-resizing that boundary syncs back into
-`@mosaic-mfact`.
-
-### Core actions
-
-| Command                        | Behavior                                                                        |
-| ------------------------------ | ------------------------------------------------------------------------------- |
-| `toggle`                       | Turn `centered-master` off on the current window.                               |
-| `relayout`                     | Re-apply the centered master column and side stacks with the current `@mosaic-mfact`. |
-| `promote`                      | Focused pane becomes the primary master. On the primary master, rotate the next master forward. |
-| `resize-master ±N`             | Change the whole center-region width for the current window, clamped to 5–95.   |
-| `select-pane -t :.-` (builtin) | Focus the previous pane in tmux pane order.                                     |
-| `select-pane -t :.+` (builtin) | Focus the next pane in tmux pane order.                                         |
-| `swap-pane -U` (builtin)       | Move the current pane earlier in tmux pane order.                               |
-| `swap-pane -D` (builtin)       | Move the current pane later in tmux pane order.                                 |
-| `split-window` (builtin)       | Add a pane and rebalance the center column plus both side stacks.               |
-| `kill-pane` (builtin)          | Remove a pane and rebalance the centered layout.                                |
-| `resize-pane` (builtin)        | Resize the center column live, then sync the new width back into `@mosaic-mfact`. |
-
-### Relevant options
-
-| Option            | Scope         | Default | Effect                                              |
-| ----------------- | ------------- | ------- | --------------------------------------------------- |
-| `@mosaic-nmaster` | window→global | `1`     | Keeps N panes in the center master column           |
-| `@mosaic-mfact`   | window→global | `50`    | Stores the center-region width as a percent         |
-| `@mosaic-step`    | global        | `5`     | Used by `resize-master` when you call it without N  |
-
-### Example config
-
-```tmux
-bind C set-option -wq @mosaic-algorithm centered-master
-bind Enter run '#{E:@mosaic-exec} promote'
-bind -r , run '#{E:@mosaic-exec} resize-master -5'
-bind -r . run '#{E:@mosaic-exec} resize-master +5'
-bind T run '#{E:@mosaic-exec} toggle'
-bind U set-option -wqu @mosaic-algorithm
-```
-
-</details>
-
-<details>
 <summary>Nix</summary>
 
 ### Nix
@@ -117,6 +68,7 @@ run-shell ${tmux-mosaic.packages.${system}.default}/share/tmux-plugins/mosaic/mo
 ```
 
 </details>
+
 
 ## Quick Start
 
@@ -250,6 +202,104 @@ and drag-resizing the master boundary syncs back into `@mosaic-mfact`.
 
 ```tmux
 bind B set-option -wq @mosaic-algorithm bottom-stack
+bind Enter run '#{E:@mosaic-exec} promote'
+bind -r , run '#{E:@mosaic-exec} resize-master -5'
+bind -r . run '#{E:@mosaic-exec} resize-master +5'
+bind T run '#{E:@mosaic-exec} toggle'
+bind U set-option -wqu @mosaic-algorithm
+```
+
+</details>
+
+<details>
+<summary><code>centered-master</code> — center master with side stacks</summary>
+
+### Behavior
+
+This keeps `@mosaic-nmaster` panes in a center column and splits the remaining
+panes into left and right stacks. If there is only one stack pane, it falls
+back to master plus right stack; otherwise the master stays centered, and an odd
+extra stack pane goes to the right. `resize-master` changes the width of the
+whole center region, and drag-resizing that boundary syncs back into
+`@mosaic-mfact`.
+
+### Core actions
+
+| Command                        | Behavior                                                                        |
+| ------------------------------ | ------------------------------------------------------------------------------- |
+| `toggle`                       | Turn `centered-master` off on the current window.                               |
+| `relayout`                     | Re-apply the centered master column and side stacks with the current `@mosaic-mfact`. |
+| `promote`                      | Focused pane becomes the primary master. On the primary master, rotate the next master forward. |
+| `resize-master ±N`             | Change the whole center-region width for the current window, clamped to 5–95.   |
+| `select-pane -t :.-` (builtin) | Focus the previous pane in tmux pane order.                                     |
+| `select-pane -t :.+` (builtin) | Focus the next pane in tmux pane order.                                         |
+| `swap-pane -U` (builtin)       | Move the current pane earlier in tmux pane order.                               |
+| `swap-pane -D` (builtin)       | Move the current pane later in tmux pane order.                                 |
+| `split-window` (builtin)       | Add a pane and rebalance the center column plus both side stacks.               |
+| `kill-pane` (builtin)          | Remove a pane and rebalance the centered layout.                                |
+| `resize-pane` (builtin)        | Resize the center column live, then sync the new width back into `@mosaic-mfact`. |
+
+### Relevant options
+
+| Option            | Scope         | Default | Effect                                              |
+| ----------------- | ------------- | ------- | --------------------------------------------------- |
+| `@mosaic-nmaster` | window→global | `1`     | Keeps N panes in the center master column           |
+| `@mosaic-mfact`   | window→global | `50`    | Stores the center-region width as a percent         |
+| `@mosaic-step`    | global        | `5`     | Used by `resize-master` when you call it without N  |
+
+### Example config
+
+```tmux
+bind C set-option -wq @mosaic-algorithm centered-master
+bind Enter run '#{E:@mosaic-exec} promote'
+bind -r , run '#{E:@mosaic-exec} resize-master -5'
+bind -r . run '#{E:@mosaic-exec} resize-master +5'
+bind T run '#{E:@mosaic-exec} toggle'
+bind U set-option -wqu @mosaic-algorithm
+```
+
+</details>
+
+<details>
+<summary><code>three-column</code> — main column plus two slave columns</summary>
+
+### Behavior
+
+This is the plain left-main sibling of `centered-master`. It keeps
+`@mosaic-nmaster` panes in a main column on the left and splits the remaining
+panes into middle and right slave columns. If there is only one stack pane, it
+falls back to main plus right stack; otherwise an odd extra stack pane goes to
+the middle column. `resize-master` changes the width of the whole main region,
+and drag-resizing that boundary syncs back into `@mosaic-mfact`.
+
+### Core actions
+
+| Command                        | Behavior                                                                        |
+| ------------------------------ | ------------------------------------------------------------------------------- |
+| `toggle`                       | Turn `three-column` off on the current window.                                  |
+| `relayout`                     | Re-apply the left main column and two slave columns with the current `@mosaic-mfact`. |
+| `promote`                      | Focused pane becomes the primary master. On the primary master, rotate the next pane forward. |
+| `resize-master ±N`             | Change the whole main-column width for the current window, clamped to 5–95.     |
+| `select-pane -t :.-` (builtin) | Focus the previous pane in tmux pane order.                                     |
+| `select-pane -t :.+` (builtin) | Focus the next pane in tmux pane order.                                         |
+| `swap-pane -U` (builtin)       | Move the current pane earlier in tmux pane order.                               |
+| `swap-pane -D` (builtin)       | Move the current pane later in tmux pane order.                                 |
+| `split-window` (builtin)       | Add a pane and rebalance the main column plus both slave columns.               |
+| `kill-pane` (builtin)          | Remove a pane and rebalance the three-column layout.                            |
+| `resize-pane` (builtin)        | Resize the main column live, then sync the new width back into `@mosaic-mfact`. |
+
+### Relevant options
+
+| Option            | Scope         | Default | Effect                                              |
+| ----------------- | ------------- | ------- | --------------------------------------------------- |
+| `@mosaic-nmaster` | window→global | `1`     | Keeps N panes in the left main column               |
+| `@mosaic-mfact`   | window→global | `50`    | Stores the main-region width as a percent           |
+| `@mosaic-step`    | global        | `5`     | Used by `resize-master` when you call it without N  |
+
+### Example config
+
+```tmux
+bind 3 set-option -wq @mosaic-algorithm three-column
 bind Enter run '#{E:@mosaic-exec} promote'
 bind -r , run '#{E:@mosaic-exec} resize-master -5'
 bind -r . run '#{E:@mosaic-exec} resize-master +5'

--- a/scripts/algorithms/three-column.sh
+++ b/scripts/algorithms/three-column.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+
+algo_pane_count() { tmux display-message -p '#{window_panes}'; }
+algo_pane_index() { tmux display-message -p '#{pane_index}'; }
+algo_pane_base() { tmux display-message -p '#{e|+|:0,#{?pane-base-index,#{pane-base-index},0}}'; }
+
+algo_mfact_for() {
+  local win="$1"
+  local val
+  val=$(tmux show-option -wqv -t "$win" "@mosaic-mfact" 2>/dev/null)
+  [[ -n "$val" ]] && {
+    echo "$val"
+    return
+  }
+  mosaic_get "@mosaic-mfact" "50"
+}
+
+algo_layout_checksum() {
+  local layout="$1" csum=0 i ch
+  for ((i = 0; i < ${#layout}; i++)); do
+    printf -v ch '%d' "'${layout:i:1}"
+    csum=$(((csum >> 1) | ((csum & 1) << 15)))
+    csum=$(((csum + ch) & 0xffff))
+  done
+  printf '%04x\n' "$csum"
+}
+
+algo_layout_leaf_id=0
+
+algo_layout_leaf() {
+  local __out="$1" sx="$2" sy="$3" x="$4" y="$5" id="$algo_layout_leaf_id"
+  algo_layout_leaf_id=$((algo_layout_leaf_id + 1))
+  printf -v "$__out" '%sx%s,%s,%s,%s' "$sx" "$sy" "$x" "$y" "$id"
+}
+
+algo_layout_split_sizes() {
+  local total="$1" count="$2" usable base rem i size out=()
+  if [[ "$count" -le 1 ]]; then
+    printf '%s\n' "$total"
+    return
+  fi
+  usable=$((total - count + 1))
+  base=$((usable / count))
+  rem=$((usable % count))
+  for ((i = 0; i < count; i++)); do
+    size=$base
+    [[ "$i" -lt "$rem" ]] && size=$((size + 1))
+    out+=("$size")
+  done
+  printf '%s\n' "${out[*]}"
+}
+
+algo_layout_column() {
+  local __out="$1" sx="$2" sy="$3" x="$4" y="$5" count="$6"
+  local node leaf size ycur
+  local -a sizes
+
+  if [[ "$count" -eq 1 ]]; then
+    algo_layout_leaf node "$sx" "$sy" "$x" "$y"
+    printf -v "$__out" '%s' "$node"
+    return
+  fi
+
+  read -r -a sizes <<<"$(algo_layout_split_sizes "$sy" "$count")"
+  node="${sx}x${sy},${x},${y}["
+  ycur=$y
+  for size in "${sizes[@]}"; do
+    algo_layout_leaf leaf "$sx" "$size" "$x" "$ycur"
+    node+="$leaf,"
+    ycur=$((ycur + size + 1))
+  done
+  node="${node%,}]"
+  printf -v "$__out" '%s' "$node"
+}
+
+algo_layout_body() {
+  local __out="$1" sx="$2" sy="$3" n="$4" nmaster="$5" mfact="$6"
+  local stack mw maxw sw middle_w right_w middle_n right_n layout master middle right
+
+  algo_layout_leaf_id=0
+
+  if [[ "$n" -eq 1 ]]; then
+    algo_layout_leaf layout "$sx" "$sy" 0 0
+    printf -v "$__out" '%s' "$layout"
+    return
+  fi
+
+  if [[ "$nmaster" -ge "$n" ]]; then
+    algo_layout_column layout "$sx" "$sy" 0 0 "$n"
+    printf -v "$__out" '%s' "$layout"
+    return
+  fi
+
+  stack=$((n - nmaster))
+  mw=$((sx * mfact / 100))
+
+  if [[ "$stack" -le 1 ]]; then
+    maxw=$((sx - 2))
+    [[ "$maxw" -lt 1 ]] && maxw=1
+    [[ "$mw" -gt "$maxw" ]] && mw=$maxw
+    [[ "$mw" -lt 1 ]] && mw=1
+    sw=$((sx - mw - 1))
+    algo_layout_column master "$mw" "$sy" 0 0 "$nmaster"
+    algo_layout_column right "$sw" "$sy" "$((mw + 1))" 0 "$stack"
+    layout="${sx}x${sy},0,0{$master,$right}"
+    printf -v "$__out" '%s' "$layout"
+    return
+  fi
+
+  maxw=$((sx - 4))
+  [[ "$maxw" -lt 1 ]] && maxw=1
+  [[ "$mw" -gt "$maxw" ]] && mw=$maxw
+  [[ "$mw" -lt 1 ]] && mw=1
+  sw=$((sx - mw - 2))
+  middle_w=$(((sw + 1) / 2))
+  right_w=$((sw - middle_w))
+  middle_n=$(((stack + 1) / 2))
+  right_n=$((stack - middle_n))
+
+  algo_layout_column master "$mw" "$sy" 0 0 "$nmaster"
+  algo_layout_column middle "$middle_w" "$sy" "$((mw + 1))" 0 "$middle_n"
+  algo_layout_column right "$right_w" "$sy" "$((mw + middle_w + 2))" 0 "$right_n"
+  layout="${sx}x${sy},0,0{$master,$middle,$right}"
+  printf -v "$__out" '%s' "$layout"
+}
+
+algo_apply_layout() {
+  local win="$1" n="$2" nmaster="$3" mfact="$4"
+  local sx sy body
+  sx=$(tmux display-message -p -t "$win" '#{window_width}' 2>/dev/null)
+  sy=$(tmux display-message -p -t "$win" '#{window_height}' 2>/dev/null)
+  [[ -z "$sx" || -z "$sy" ]] && return 0
+  algo_layout_body body "$sx" "$sy" "$n" "$nmaster" "$mfact"
+  tmux select-layout -t "$win" "$(algo_layout_checksum "$body"),$body" 2>/dev/null || true
+}
+
+algo_swap_keep_focus() {
+  local pid
+  pid=$(tmux display-message -p '#{pane_id}')
+  tmux swap-pane "$@"
+  tmux select-pane -t "$pid"
+}
+
+algo_bubble_keep_focus() {
+  local from="$1" to="$2"
+  while [[ "$from" -gt "$to" ]]; do
+    algo_swap_keep_focus -s ":.$from" -t ":.$((from - 1))"
+    from=$((from - 1))
+  done
+  while [[ "$from" -lt "$to" ]]; do
+    algo_swap_keep_focus -s ":.$from" -t ":.$((from + 1))"
+    from=$((from + 1))
+  done
+}
+
+algo_relayout() {
+  local win n mfact nmaster pbase
+  win=$(mosaic_resolve_window "${1:-}")
+  n=$(mosaic_window_pane_count "$win")
+  mosaic_can_relayout_window "$win" "$n" || return 0
+  mfact=$(algo_mfact_for "$win")
+  nmaster=$(mosaic_effective_nmaster "$win" "$n")
+  pbase=$(algo_pane_base)
+
+  algo_apply_layout "$win" "$n" "$nmaster" "$mfact"
+
+  mosaic_log "relayout: win=$win n=$n layout=three-column nmaster=$nmaster mfact=$mfact pbase=$pbase"
+}
+
+algo_toggle() { mosaic_toggle_window algo_relayout; }
+
+algo_promote() {
+  local idx n win nmaster pbase stack_top
+  idx=$(algo_pane_index)
+  win=$(mosaic_current_window)
+  n=$(mosaic_window_pane_count "$win")
+  nmaster=$(mosaic_effective_nmaster "$win" "$n")
+  pbase=$(algo_pane_base)
+
+  [[ "$n" -le 1 ]] && return 0
+
+  if [[ "$idx" -eq "$pbase" ]]; then
+    if [[ "$nmaster" -gt 1 ]]; then
+      algo_swap_keep_focus -s ":.$pbase" -t ":.$((pbase + 1))"
+    else
+      stack_top=$((pbase + nmaster))
+      [[ "$stack_top" -ne "$pbase" ]] && algo_swap_keep_focus -s ":.$pbase" -t ":.$stack_top"
+    fi
+  else
+    algo_bubble_keep_focus "$idx" "$pbase"
+  fi
+  algo_relayout
+}
+
+algo_resize_master() {
+  local delta="${1:-}"
+  if [[ -z "$delta" ]]; then
+    delta=$(mosaic_get "@mosaic-step" "5")
+  fi
+  local win cur new
+  win=$(mosaic_current_window)
+  cur=$(algo_mfact_for "$win")
+  new=$((cur + delta))
+  [[ "$new" -lt 5 ]] && new=5
+  [[ "$new" -gt 95 ]] && new=95
+  tmux set-option -wq -t "$win" "@mosaic-mfact" "$new"
+  algo_relayout "$win"
+}
+
+algo_sync_state() {
+  local win="$1"
+  mosaic_enabled "$win" || return 0
+  [[ "$(mosaic_window_zoomed "$win")" == "1" ]] && return 0
+
+  local n nmaster
+  n=$(mosaic_window_pane_count "$win")
+  [[ "$n" -le 1 ]] && return 0
+  nmaster=$(mosaic_effective_nmaster "$win" "$n")
+  [[ "$nmaster" -ge "$n" ]] && return 0
+
+  local pbase pane_size window_size pct
+  pbase=$(algo_pane_base)
+  pane_size=$(tmux display-message -p -t "$win.$pbase" '#{pane_width}' 2>/dev/null)
+  window_size=$(tmux display-message -p -t "$win" '#{window_width}' 2>/dev/null)
+  [[ -z "$pane_size" ]] && return 0
+  [[ -z "$window_size" || "$window_size" -le 0 ]] && return 0
+
+  pct=$((pane_size * 100 / window_size))
+  [[ "$pct" -lt 5 ]] && pct=5
+  [[ "$pct" -gt 95 ]] && pct=95
+
+  tmux set-option -wq -t "$win" "@mosaic-mfact" "$pct"
+  mosaic_log "sync-state: win=$win layout=three-column pbase=$pbase pane_size=$pane_size window_size=$window_size pct=$pct"
+}

--- a/tests/integration/three_column.bats
+++ b/tests/integration/three_column.bats
@@ -1,0 +1,149 @@
+#!/usr/bin/env bats
+
+load '../helpers.bash'
+
+setup() {
+  mosaic_setup_server
+  mosaic_use_algorithm three-column
+}
+
+teardown() {
+  mosaic_teardown_server
+}
+
+set_nmaster() {
+  mosaic_t set-option -wq -t "${1:-t:1}" "@mosaic-nmaster" "${2:?nmaster required}"
+}
+
+pane_field() {
+  mosaic_t list-panes -t "${1:-t:1}" -F '#{pane_index} #{pane_left} #{pane_top} #{pane_width} #{pane_height}' |
+    awk -v idx="${2:?pane index required}" -v field="${3:?field required}" '$1 == idx { print $field }'
+}
+
+@test "three-column: 2 panes fall back to main plus one slave column" {
+  mosaic_split
+  [ "$(mosaic_pane_count)" = "2" ]
+
+  [ "$(pane_field t:1 1 2)" = "0" ]
+  [ "$(pane_field t:1 2 2)" -gt 0 ]
+  [ "$(pane_field t:1 1 4)" -gt "$(pane_field t:1 2 4)" ]
+}
+
+@test "three-column: 3 panes create main, middle, and right columns" {
+  for _ in 1 2; do mosaic_split; done
+  [ "$(mosaic_pane_count)" = "3" ]
+
+  layout=$(mosaic_layout)
+  [[ "$layout" == *"{"* ]]
+
+  [ "$(pane_field t:1 1 2)" = "0" ]
+  [ "$(pane_field t:1 2 2)" -gt 0 ]
+  [ "$(pane_field t:1 3 2)" -gt "$(pane_field t:1 2 2)" ]
+  [ "$(pane_field t:1 1 4)" -gt "$(pane_field t:1 2 4)" ]
+
+  diff=$(($(pane_field t:1 2 4) - $(pane_field t:1 3 4)))
+  [ "${diff#-}" -le 1 ]
+}
+
+@test "three-column: 4 panes give the extra slave pane to the middle column" {
+  for _ in 1 2 3; do mosaic_split; done
+  [ "$(mosaic_pane_count)" = "4" ]
+
+  [ "$(pane_field t:1 1 2)" = "0" ]
+  [ "$(pane_field t:1 2 2)" -gt 0 ]
+  [ "$(pane_field t:1 3 2)" = "$(pane_field t:1 2 2)" ]
+  [ "$(pane_field t:1 4 2)" -gt "$(pane_field t:1 2 2)" ]
+
+  diff=$(($(pane_field t:1 2 5) - $(pane_field t:1 3 5)))
+  [ "${diff#-}" -le 1 ]
+}
+
+@test "three-column: 5 panes split the slave columns evenly" {
+  for _ in 1 2 3 4; do mosaic_split; done
+  [ "$(mosaic_pane_count)" = "5" ]
+
+  [ "$(pane_field t:1 2 2)" = "$(pane_field t:1 3 2)" ]
+  [ "$(pane_field t:1 4 2)" = "$(pane_field t:1 5 2)" ]
+  [ "$(pane_field t:1 4 2)" -gt "$(pane_field t:1 2 2)" ]
+
+  middle_diff=$(($(pane_field t:1 2 5) - $(pane_field t:1 3 5)))
+  right_diff=$(($(pane_field t:1 4 5) - $(pane_field t:1 5 5)))
+  [ "${middle_diff#-}" -le 1 ]
+  [ "${right_diff#-}" -le 1 ]
+}
+
+@test "three-column: nmaster 2 keeps both masters in the left column" {
+  set_nmaster t:1 2
+  for _ in 1 2 3; do mosaic_split; done
+
+  [ "$(pane_field t:1 1 2)" = "0" ]
+  [ "$(pane_field t:1 2 2)" = "0" ]
+  [ "$(pane_field t:1 3 2)" -gt 0 ]
+  [ "$(pane_field t:1 4 2)" -gt "$(pane_field t:1 3 2)" ]
+
+  diff=$(($(pane_field t:1 1 5) - $(pane_field t:1 2 5)))
+  [ "${diff#-}" -le 1 ]
+}
+
+@test "three-column: promote from a slave pane makes it the primary master" {
+  for _ in 1 2 3; do mosaic_split; done
+  mosaic_t select-pane -t t:1.4
+  pid=$(mosaic_t display-message -p -t t:1 '#{pane_id}')
+
+  mosaic_op promote
+
+  [ "$(mosaic_pane_index)" = "1" ]
+  [ "$(mosaic_pane_id_at t:1.1)" = "$pid" ]
+}
+
+@test "three-column: promote on the primary master rotates the next master forward when nmaster is 2" {
+  set_nmaster t:1 2
+  for _ in 1 2 3; do mosaic_split; done
+  master1_pid=$(mosaic_pane_id_at t:1.1)
+  master2_pid=$(mosaic_pane_id_at t:1.2)
+  mosaic_t select-pane -t t:1.1
+
+  mosaic_op promote
+
+  [ "$(mosaic_pane_id_at t:1.1)" = "$master2_pid" ]
+  [ "$(mosaic_pane_id_at t:1.2)" = "$master1_pid" ]
+}
+
+@test "three-column: resize-master changes the main column width" {
+  for _ in 1 2 3; do mosaic_split; done
+
+  mosaic_op resize-master +10
+
+  [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
+  pane1_w=$(pane_field t:1 1 4)
+  pane2_w=$(pane_field t:1 2 4)
+  [ "$pane1_w" -ge 118 ]
+  [ "$pane1_w" -le 121 ]
+  [ "$pane1_w" -gt "$pane2_w" ]
+}
+
+@test "three-column: kill-pane keeps the three-column shape" {
+  for _ in 1 2 3 4; do mosaic_split; done
+  [ "$(mosaic_pane_count)" = "5" ]
+
+  mosaic_t kill-pane -t t:1.3
+  sleep 0.2
+
+  [ "$(mosaic_pane_count)" = "4" ]
+  [ "$(pane_field t:1 1 2)" = "0" ]
+  [ "$(pane_field t:1 2 2)" -gt 0 ]
+  [ "$(pane_field t:1 3 2)" = "$(pane_field t:1 2 2)" ]
+  [ "$(pane_field t:1 4 2)" -gt "$(pane_field t:1 2 2)" ]
+}
+
+@test "three-column: drag-resize syncs mfact from the main width" {
+  for _ in 1 2; do mosaic_split; done
+  mosaic_t resize-pane -t t:1.1 -x 120
+  sleep 0.2
+  [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
+
+  mosaic_split
+  pane1_w=$(pane_field t:1 1 4)
+  [ "$pane1_w" -ge 118 ]
+  [ "$pane1_w" -le 121 ]
+}


### PR DESCRIPTION
## Problem

Mosaic has `centered-master`, but it still lacks the plain `ThreeCol`-style
layout with a left main column and two slave columns. The README also had the
`centered-master` layout docs in the Installation section instead of under
`## Layouts`.

## Solution

Add `scripts/algorithms/three-column.sh` with `@mosaic-nmaster`,
`promote`, `resize-master`, and drag-resize sync support, plus integration
coverage in `tests/integration/three_column.bats`. Document `three-column`
in `README.md` and move the misplaced `centered-master` docs into
`## Layouts`.
