### PR TITLE
feat(algorithm): add dwindle

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,54 @@ bind U set-option -wqu @mosaic-algorithm
 </details>
 
 <details>
+<summary><code>dwindle</code> — shrinking Fibonacci sibling of spiral</summary>
+
+### Behavior
+
+This is the shrinking sibling of `spiral`, following the dwm fibonacci
+`dwindle` layout. The first pane gets a primary region on the left sized by
+`@mosaic-mfact`, and the remaining panes recurse through the leftover space in
+a steadily shrinking bottom-right pattern. `promote` bubbles the focused pane
+into the primary slot, `resize-master` changes the first split, and
+drag-resizing that primary boundary syncs back into `@mosaic-mfact`.
+
+### Core actions
+
+| Command                        | Behavior                                                                  |
+| ------------------------------ | ------------------------------------------------------------------------- |
+| `toggle`                       | Turn `dwindle` off on the current window.                                 |
+| `relayout`                     | Re-apply the current shrinking Fibonacci layout with the current `@mosaic-mfact`. |
+| `promote`                      | Focused pane becomes the primary pane. On the primary pane, rotate the next pane forward. |
+| `resize-master ±N`             | Change the first split width for the current window, clamped to 5–95.     |
+| `select-pane -t :.-` (builtin) | Focus the previous pane in tmux pane order.                               |
+| `select-pane -t :.+` (builtin) | Focus the next pane in tmux pane order.                                   |
+| `swap-pane -U` (builtin)       | Move the current pane earlier in tmux pane order.                         |
+| `swap-pane -D` (builtin)       | Move the current pane later in tmux pane order.                           |
+| `split-window` (builtin)       | Add a pane and rebalance the recursive dwindle pattern.                   |
+| `kill-pane` (builtin)          | Remove a pane and rebalance the recursive dwindle pattern.                |
+| `resize-pane` (builtin)        | Resize the primary pane live, then sync the new width back into `@mosaic-mfact`. |
+
+### Relevant options
+
+| Option          | Scope         | Default | Effect                                              |
+| --------------- | ------------- | ------- | --------------------------------------------------- |
+| `@mosaic-mfact` | window→global | `50`    | Stores the primary-split width as a percent         |
+| `@mosaic-step`  | global        | `5`     | Used by `resize-master` when you call it without N  |
+
+### Example config
+
+```tmux
+bind D set-option -wq @mosaic-algorithm dwindle
+bind Enter run '#{E:@mosaic-exec} promote'
+bind -r , run '#{E:@mosaic-exec} resize-master -5'
+bind -r . run '#{E:@mosaic-exec} resize-master +5'
+bind T run '#{E:@mosaic-exec} toggle'
+bind U set-option -wqu @mosaic-algorithm
+```
+
+</details>
+
+<details>
 <summary><code>bottom-stack</code> — master above, stack below</summary>
 
 ### Behavior

--- a/scripts/algorithms/dwindle.sh
+++ b/scripts/algorithms/dwindle.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-algo_fibonacci_variant() { printf '%s\n' "spiral"; }
+algo_fibonacci_variant() { printf '%s\n' "dwindle"; }
 
 algo_relayout() { mosaic_fibonacci_relayout "$@"; }
 algo_toggle() { mosaic_toggle_window algo_relayout; }

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -179,6 +179,270 @@ mosaic_relayout_simple() {
   mosaic_log "relayout: win=$win n=$n layout=$layout"
 }
 
+mosaic_current_pane_index() { tmux display-message -p '#{pane_index}'; }
+
+mosaic_current_pane_base() {
+  tmux display-message -p '#{e|+|:0,#{?pane-base-index,#{pane-base-index},0}}'
+}
+
+mosaic_fibonacci_variant() {
+  if declare -f algo_fibonacci_variant >/dev/null 2>&1; then
+    algo_fibonacci_variant
+  else
+    printf '%s\n' "spiral"
+  fi
+}
+
+mosaic_fibonacci_mfact_for() {
+  local win="$1" val
+  val=$(tmux show-option -wqv -t "$win" "@mosaic-mfact" 2>/dev/null)
+  [[ -n "$val" ]] && {
+    printf '%s\n' "$val"
+    return
+  }
+  mosaic_get "@mosaic-mfact" "50"
+}
+
+mosaic_fibonacci_layout_checksum() {
+  local layout="$1" csum=0 i ch
+  for ((i = 0; i < ${#layout}; i++)); do
+    printf -v ch '%d' "'${layout:i:1}"
+    csum=$(((csum >> 1) | ((csum & 1) << 15)))
+    csum=$(((csum + ch) & 0xffff))
+  done
+  printf '%04x\n' "$csum"
+}
+
+mosaic_fibonacci_layout_leaf_id=0
+
+mosaic_fibonacci_layout_leaf() {
+  local __out="$1" sx="$2" sy="$3" x="$4" y="$5" id="$mosaic_fibonacci_layout_leaf_id"
+  mosaic_fibonacci_layout_leaf_id=$((mosaic_fibonacci_layout_leaf_id + 1))
+  printf -v "$__out" '%sx%s,%s,%s,%s' "$sx" "$sy" "$x" "$y" "$id"
+}
+
+mosaic_fibonacci_layout_split_primary() {
+  local __first="$1" __second="$2" total="$3" pct="$4"
+  local first max second
+  first=$((total * pct / 100))
+  max=$((total - 2))
+  [[ "$max" -lt 1 ]] && max=1
+  [[ "$first" -lt 1 ]] && first=1
+  [[ "$first" -gt "$max" ]] && first=$max
+  second=$((total - first - 1))
+  printf -v "$__first" '%s' "$first"
+  printf -v "$__second" '%s' "$second"
+}
+
+mosaic_fibonacci_layout_split_half() {
+  local __first="$1" __second="$2" total="$3"
+  local usable first second
+  usable=$((total - 1))
+  first=$(((usable + 1) / 2))
+  second=$((usable - first))
+  printf -v "$__first" '%s' "$first"
+  printf -v "$__second" '%s' "$second"
+}
+
+mosaic_fibonacci_layout_step() {
+  local __split="$1" __order="$2" __next="$3" step="$4"
+  local variant value_split value_order value_next
+  variant=$(mosaic_fibonacci_variant)
+  case "$variant:$step" in
+  spiral:0 | dwindle:0)
+    value_split="primary"
+    value_order="leaf-node"
+    value_next=1
+    ;;
+  spiral:1 | dwindle:1)
+    value_split="y"
+    value_order="leaf-node"
+    value_next=2
+    ;;
+  spiral:2)
+    value_split="x"
+    value_order="node-leaf"
+    value_next=3
+    ;;
+  spiral:3)
+    value_split="y"
+    value_order="node-leaf"
+    value_next=4
+    ;;
+  spiral:4)
+    value_split="x"
+    value_order="leaf-node"
+    value_next=1
+    ;;
+  dwindle:2)
+    value_split="x"
+    value_order="leaf-node"
+    value_next=1
+    ;;
+  esac
+  printf -v "$__split" '%s' "$value_split"
+  printf -v "$__order" '%s' "$value_order"
+  printf -v "$__next" '%s' "$value_next"
+}
+
+mosaic_fibonacci_layout_node() {
+  local __out="$1" sx="$2" sy="$3" x="$4" y="$5" n="$6" step="$7" mfact="$8"
+  local split order next axis container
+  local node_a_var="${__out}_a" node_b_var="${__out}_b" first_size second_size
+
+  if [[ "$n" -eq 1 ]]; then
+    mosaic_fibonacci_layout_leaf "$__out" "$sx" "$sy" "$x" "$y"
+    return
+  fi
+
+  mosaic_fibonacci_layout_step split order next "$step"
+  case "$split" in
+  primary)
+    mosaic_fibonacci_layout_split_primary first_size second_size "$sx" "$mfact"
+    axis="x"
+    container="{}"
+    ;;
+  x)
+    mosaic_fibonacci_layout_split_half first_size second_size "$sx"
+    axis="x"
+    container="{}"
+    ;;
+  y)
+    mosaic_fibonacci_layout_split_half first_size second_size "$sy"
+    axis="y"
+    container="[]"
+    ;;
+  esac
+
+  if [[ "$axis" == "x" ]]; then
+    if [[ "$order" == "leaf-node" ]]; then
+      mosaic_fibonacci_layout_leaf "$node_a_var" "$first_size" "$sy" "$x" "$y"
+      mosaic_fibonacci_layout_node "$node_b_var" "$second_size" "$sy" "$((x + first_size + 1))" "$y" "$((n - 1))" "$next" "$mfact"
+    else
+      mosaic_fibonacci_layout_node "$node_a_var" "$first_size" "$sy" "$x" "$y" "$((n - 1))" "$next" "$mfact"
+      mosaic_fibonacci_layout_leaf "$node_b_var" "$second_size" "$sy" "$((x + first_size + 1))" "$y"
+    fi
+  else
+    if [[ "$order" == "leaf-node" ]]; then
+      mosaic_fibonacci_layout_leaf "$node_a_var" "$sx" "$first_size" "$x" "$y"
+      mosaic_fibonacci_layout_node "$node_b_var" "$sx" "$second_size" "$x" "$((y + first_size + 1))" "$((n - 1))" "$next" "$mfact"
+    else
+      mosaic_fibonacci_layout_node "$node_a_var" "$sx" "$first_size" "$x" "$y" "$((n - 1))" "$next" "$mfact"
+      mosaic_fibonacci_layout_leaf "$node_b_var" "$sx" "$second_size" "$x" "$((y + first_size + 1))"
+    fi
+  fi
+
+  if [[ "$container" == "{}" ]]; then
+    printf -v "$__out" '%sx%s,%s,%s{%s,%s}' "$sx" "$sy" "$x" "$y" "${!node_a_var}" "${!node_b_var}"
+  else
+    printf -v "$__out" '%sx%s,%s,%s[%s,%s]' "$sx" "$sy" "$x" "$y" "${!node_a_var}" "${!node_b_var}"
+  fi
+}
+
+mosaic_fibonacci_layout_body() {
+  local __out="$1" sx="$2" sy="$3" n="$4" mfact="$5"
+  local layout
+  mosaic_fibonacci_layout_leaf_id=0
+  mosaic_fibonacci_layout_node layout "$sx" "$sy" 0 0 "$n" 0 "$mfact"
+  printf -v "$__out" '%s' "$layout"
+}
+
+mosaic_fibonacci_apply_layout() {
+  local win="$1" n="$2" mfact="$3"
+  local sx sy body
+  sx=$(tmux display-message -p -t "$win" '#{window_width}' 2>/dev/null)
+  sy=$(tmux display-message -p -t "$win" '#{window_height}' 2>/dev/null)
+  [[ -z "$sx" || -z "$sy" ]] && return 0
+  mosaic_fibonacci_layout_body body "$sx" "$sy" "$n" "$mfact"
+  tmux select-layout -t "$win" "$(mosaic_fibonacci_layout_checksum "$body"),$body" 2>/dev/null || true
+}
+
+mosaic_fibonacci_swap_keep_focus() {
+  local pid
+  pid=$(tmux display-message -p '#{pane_id}')
+  tmux swap-pane "$@"
+  tmux select-pane -t "$pid"
+}
+
+mosaic_fibonacci_bubble_keep_focus() {
+  local from="$1" to="$2"
+  while [[ "$from" -gt "$to" ]]; do
+    mosaic_fibonacci_swap_keep_focus -s ":.$from" -t ":.$((from - 1))"
+    from=$((from - 1))
+  done
+}
+
+mosaic_fibonacci_relayout() {
+  local variant win n mfact pbase
+  variant=$(mosaic_fibonacci_variant)
+  win=$(mosaic_resolve_window "${1:-}")
+  n=$(mosaic_window_pane_count "$win")
+  mosaic_can_relayout_window "$win" "$n" || return 0
+  mfact=$(mosaic_fibonacci_mfact_for "$win")
+  pbase=$(mosaic_current_pane_base)
+
+  mosaic_fibonacci_apply_layout "$win" "$n" "$mfact"
+
+  mosaic_log "relayout: win=$win n=$n layout=$variant mfact=$mfact pbase=$pbase"
+}
+
+mosaic_fibonacci_promote() {
+  local idx n pbase win
+  idx=$(mosaic_current_pane_index)
+  win=$(mosaic_current_window)
+  n=$(mosaic_window_pane_count "$win")
+  pbase=$(mosaic_current_pane_base)
+
+  [[ "$n" -le 1 ]] && return 0
+
+  if [[ "$idx" -eq "$pbase" ]]; then
+    mosaic_fibonacci_swap_keep_focus -s ":.$pbase" -t ":.$((pbase + 1))"
+  else
+    mosaic_fibonacci_bubble_keep_focus "$idx" "$pbase"
+  fi
+  mosaic_fibonacci_relayout
+}
+
+mosaic_fibonacci_resize_master() {
+  local delta="${1:-}"
+  if [[ -z "$delta" ]]; then
+    delta=$(mosaic_get "@mosaic-step" "5")
+  fi
+  local win cur new
+  win=$(mosaic_current_window)
+  cur=$(mosaic_fibonacci_mfact_for "$win")
+  new=$((cur + delta))
+  [[ "$new" -lt 5 ]] && new=5
+  [[ "$new" -gt 95 ]] && new=95
+  tmux set-option -wq -t "$win" "@mosaic-mfact" "$new"
+  mosaic_fibonacci_relayout "$win"
+}
+
+mosaic_fibonacci_sync_state() {
+  local variant win="$1"
+  variant=$(mosaic_fibonacci_variant)
+  mosaic_enabled "$win" || return 0
+  [[ "$(mosaic_window_zoomed "$win")" == "1" ]] && return 0
+
+  local n
+  n=$(mosaic_window_pane_count "$win")
+  [[ "$n" -le 1 ]] && return 0
+
+  local pbase pane_size window_size pct
+  pbase=$(mosaic_current_pane_base)
+  pane_size=$(tmux display-message -p -t "$win.$pbase" '#{pane_width}' 2>/dev/null)
+  window_size=$(tmux display-message -p -t "$win" '#{window_width}' 2>/dev/null)
+  [[ -z "$pane_size" ]] && return 0
+  [[ -z "$window_size" || "$window_size" -le 0 ]] && return 0
+
+  pct=$((pane_size * 100 / window_size))
+  [[ "$pct" -lt 5 ]] && pct=5
+  [[ "$pct" -gt 95 ]] && pct=95
+
+  tmux set-option -wq -t "$win" "@mosaic-mfact" "$pct"
+  mosaic_log "sync-state: win=$win layout=$variant pbase=$pbase pane_size=$pane_size window_size=$window_size pct=$pct"
+}
+
 mosaic_log() {
   local debug
   debug=$(mosaic_get "@mosaic-debug" "0")

--- a/tests/integration/dwindle.bats
+++ b/tests/integration/dwindle.bats
@@ -1,0 +1,132 @@
+#!/usr/bin/env bats
+
+load '../helpers.bash'
+
+setup() {
+  mosaic_setup_server
+  mosaic_use_algorithm dwindle
+}
+
+teardown() {
+  mosaic_teardown_server
+}
+
+pane_field() {
+  mosaic_t list-panes -t "${1:-t:1}" -F '#{pane_index} #{pane_left} #{pane_top} #{pane_width} #{pane_height}' |
+    awk -v idx="${2:?pane index required}" -v field="${3:?field required}" '$1 == idx { print $field }'
+}
+
+@test "dwindle: 2 panes keep the primary pane on the left" {
+  mosaic_split
+  [ "$(mosaic_pane_count)" = "2" ]
+
+  [ "$(pane_field t:1 1 2)" = "0" ]
+  [ "$(pane_field t:1 2 2)" -gt 0 ]
+  [ "$(pane_field t:1 1 4)" -gt "$(pane_field t:1 2 4)" ]
+  [ "$(pane_field t:1 1 5)" = "$(pane_field t:1 2 5)" ]
+}
+
+@test "dwindle: 3 panes place the third pane below the second" {
+  for _ in 1 2; do mosaic_split; done
+  [ "$(mosaic_pane_count)" = "3" ]
+
+  layout=$(mosaic_layout)
+  [[ "$layout" == *"{"* ]]
+  [[ "$layout" == *"["* ]]
+
+  [ "$(pane_field t:1 2 2)" -gt 0 ]
+  [ "$(pane_field t:1 3 2)" = "$(pane_field t:1 2 2)" ]
+  [ "$(pane_field t:1 3 3)" -gt "$(pane_field t:1 2 3)" ]
+  [ "$(pane_field t:1 1 4)" -gt "$(pane_field t:1 2 4)" ]
+}
+
+@test "dwindle: 4 panes split the lower-right area left then right" {
+  for _ in 1 2 3; do mosaic_split; done
+  [ "$(mosaic_pane_count)" = "4" ]
+
+  [ "$(pane_field t:1 3 3)" -gt "$(pane_field t:1 2 3)" ]
+  [ "$(pane_field t:1 4 3)" = "$(pane_field t:1 3 3)" ]
+  [ "$(pane_field t:1 4 2)" -gt "$(pane_field t:1 3 2)" ]
+  [ "$(pane_field t:1 2 4)" -gt "$(pane_field t:1 3 4)" ]
+}
+
+@test "dwindle: 5 panes keep shrinking down the right edge" {
+  for _ in 1 2 3 4; do mosaic_split; done
+  [ "$(mosaic_pane_count)" = "5" ]
+
+  [ "$(pane_field t:1 4 2)" -gt "$(pane_field t:1 3 2)" ]
+  [ "$(pane_field t:1 5 2)" = "$(pane_field t:1 4 2)" ]
+  [ "$(pane_field t:1 5 3)" -gt "$(pane_field t:1 4 3)" ]
+  [ "$(pane_field t:1 4 4)" = "$(pane_field t:1 5 4)" ]
+}
+
+@test "dwindle: 6 panes keep shrinking into the lower-right corner" {
+  for _ in 1 2 3 4 5; do mosaic_split; done
+  [ "$(mosaic_pane_count)" = "6" ]
+
+  [ "$(pane_field t:1 5 3)" -gt "$(pane_field t:1 4 3)" ]
+  [ "$(pane_field t:1 6 3)" = "$(pane_field t:1 5 3)" ]
+  [ "$(pane_field t:1 6 2)" -gt "$(pane_field t:1 5 2)" ]
+  [ "$(pane_field t:1 5 4)" = "$(pane_field t:1 6 4)" ]
+}
+
+@test "dwindle: promote from a deep pane makes it the primary pane" {
+  for _ in 1 2 3 4; do mosaic_split; done
+  mosaic_t select-pane -t t:1.5
+  pid=$(mosaic_t display-message -p -t t:1 '#{pane_id}')
+
+  mosaic_op promote
+
+  [ "$(mosaic_pane_index)" = "1" ]
+  [ "$(mosaic_pane_id_at t:1.1)" = "$pid" ]
+}
+
+@test "dwindle: promote on the primary pane swaps with the next pane" {
+  for _ in 1 2; do mosaic_split; done
+  master_pid=$(mosaic_pane_id_at t:1.1)
+  next_pid=$(mosaic_pane_id_at t:1.2)
+  mosaic_t select-pane -t t:1.1
+
+  mosaic_op promote
+
+  [ "$(mosaic_pane_id_at t:1.1)" = "$next_pid" ]
+  [ "$(mosaic_pane_id_at t:1.2)" = "$master_pid" ]
+}
+
+@test "dwindle: resize-master changes the first split width" {
+  for _ in 1 2; do mosaic_split; done
+
+  mosaic_op resize-master +10
+
+  [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
+  pane1_w=$(pane_field t:1 1 4)
+  pane2_w=$(pane_field t:1 2 4)
+  [ "$pane1_w" -ge 118 ]
+  [ "$pane1_w" -le 121 ]
+  [ "$pane1_w" -gt "$pane2_w" ]
+}
+
+@test "dwindle: kill-pane keeps the recursive shape" {
+  for _ in 1 2 3 4 5; do mosaic_split; done
+  [ "$(mosaic_pane_count)" = "6" ]
+
+  mosaic_t kill-pane -t t:1.5
+  sleep 0.2
+
+  [ "$(mosaic_pane_count)" = "5" ]
+  [ "$(pane_field t:1 4 2)" -gt "$(pane_field t:1 3 2)" ]
+  [ "$(pane_field t:1 5 2)" = "$(pane_field t:1 4 2)" ]
+  [ "$(pane_field t:1 5 3)" -gt "$(pane_field t:1 4 3)" ]
+}
+
+@test "dwindle: drag-resize syncs mfact from the primary width" {
+  for _ in 1 2; do mosaic_split; done
+  mosaic_t resize-pane -t t:1.1 -x 120
+  sleep 0.3
+  [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
+
+  mosaic_split
+  pane1_w=$(pane_field t:1 1 4)
+  [ "$pane1_w" -ge 118 ]
+  [ "$pane1_w" -le 121 ]
+}


### PR DESCRIPTION
## Problem

`tmux-mosaic` is missing a tmux-native shrinking Fibonacci layout, and `spiral` and `dwindle` would otherwise duplicate the same recursive layout machinery.

## Solution

Add `dwindle`, move the shared Fibonacci relayout/promote/resize helpers into `scripts/helpers.sh`, cover the new layout with integration tests, and document it in `README.md`. Closes #49.