### PR TITLE
refactor(promote): share pane-move helpers

### DIFF
--- a/scripts/algorithms/bottom-stack.sh
+++ b/scripts/algorithms/bottom-stack.sh
@@ -21,21 +21,6 @@ algo_mfact_for() {
   mosaic_get "@mosaic-mfact" "50"
 }
 
-algo_swap_keep_focus() {
-  local pid
-  pid=$(tmux display-message -p '#{pane_id}')
-  tmux swap-pane "$@"
-  tmux select-pane -t "$pid"
-}
-
-algo_bubble_keep_focus() {
-  local from="$1" to="$2"
-  while [[ "$from" -gt "$to" ]]; do
-    algo_swap_keep_focus -s ":.$from" -t ":.$((from - 1))"
-    from=$((from - 1))
-  done
-}
-
 algo_join_extra_masters() {
   local win="$1" nmaster="$2" n="$3" pbase="$4"
   local idx
@@ -76,9 +61,9 @@ algo_promote() {
   [[ "$n" -le 1 ]] && return 0
 
   if [[ "$idx" -eq "$pbase" ]]; then
-    algo_swap_keep_focus -s ":.$pbase" -t ":.$((pbase + 1))"
+    mosaic_swap_keep_focus -s ":.$pbase" -t ":.$((pbase + 1))"
   else
-    algo_bubble_keep_focus "$idx" "$pbase"
+    mosaic_bubble_keep_focus "$idx" "$pbase"
   fi
   algo_relayout
 }

--- a/scripts/algorithms/centered-master.sh
+++ b/scripts/algorithms/centered-master.sh
@@ -134,25 +134,6 @@ algo_apply_layout() {
   tmux select-layout -t "$win" "$(algo_layout_checksum "$body"),$body" 2>/dev/null || true
 }
 
-algo_swap_keep_focus() {
-  local pid
-  pid=$(tmux display-message -p '#{pane_id}')
-  tmux swap-pane "$@"
-  tmux select-pane -t "$pid"
-}
-
-algo_bubble_keep_focus() {
-  local from="$1" to="$2"
-  while [[ "$from" -gt "$to" ]]; do
-    algo_swap_keep_focus -s ":.$from" -t ":.$((from - 1))"
-    from=$((from - 1))
-  done
-  while [[ "$from" -lt "$to" ]]; do
-    algo_swap_keep_focus -s ":.$from" -t ":.$((from + 1))"
-    from=$((from + 1))
-  done
-}
-
 algo_left_stack_count() {
   local n="$1" nmaster="$2" stack
   stack=$((n - nmaster))
@@ -209,13 +190,13 @@ algo_promote() {
 
   if [[ "$idx" -eq "$master_base" ]]; then
     if [[ "$nmaster" -gt 1 ]]; then
-      algo_swap_keep_focus -s ":.$master_base" -t ":.$((master_base + 1))"
+      mosaic_swap_keep_focus -s ":.$master_base" -t ":.$((master_base + 1))"
     else
       stack_top=$(algo_stack_top "$n" "$nmaster" "$pbase" "$master_base")
-      [[ "$stack_top" -ne "$master_base" ]] && algo_swap_keep_focus -s ":.$master_base" -t ":.$stack_top"
+      [[ "$stack_top" -ne "$master_base" ]] && mosaic_swap_keep_focus -s ":.$master_base" -t ":.$stack_top"
     fi
   else
-    algo_bubble_keep_focus "$idx" "$master_base"
+    mosaic_bubble_keep_focus "$idx" "$master_base"
   fi
   algo_relayout
 }

--- a/scripts/algorithms/master-stack.sh
+++ b/scripts/algorithms/master-stack.sh
@@ -65,21 +65,6 @@ algo_mfact_for() {
   mosaic_get "@mosaic-mfact" "50"
 }
 
-algo_swap_keep_focus() {
-  local pid
-  pid=$(tmux display-message -p '#{pane_id}')
-  tmux swap-pane "$@"
-  tmux select-pane -t "$pid"
-}
-
-algo_bubble_keep_focus() {
-  local from="$1" to="$2"
-  while [[ "$from" -gt "$to" ]]; do
-    algo_swap_keep_focus -s ":.$from" -t ":.$((from - 1))"
-    from=$((from - 1))
-  done
-}
-
 algo_join_extra_masters() {
   local win="$1" orientation="$2" nmaster="$3" n="$4" pbase="$5"
   local flag idx
@@ -122,9 +107,9 @@ algo_promote() {
   [[ "$n" -le 1 ]] && return 0
 
   if [[ "$idx" -eq "$pbase" ]]; then
-    algo_swap_keep_focus -s ":.$pbase" -t ":.$((pbase + 1))"
+    mosaic_swap_keep_focus -s ":.$pbase" -t ":.$((pbase + 1))"
   else
-    algo_bubble_keep_focus "$idx" "$pbase"
+    mosaic_bubble_keep_focus "$idx" "$pbase"
   fi
   algo_relayout
 }

--- a/scripts/algorithms/three-column.sh
+++ b/scripts/algorithms/three-column.sh
@@ -134,25 +134,6 @@ algo_apply_layout() {
   tmux select-layout -t "$win" "$(algo_layout_checksum "$body"),$body" 2>/dev/null || true
 }
 
-algo_swap_keep_focus() {
-  local pid
-  pid=$(tmux display-message -p '#{pane_id}')
-  tmux swap-pane "$@"
-  tmux select-pane -t "$pid"
-}
-
-algo_bubble_keep_focus() {
-  local from="$1" to="$2"
-  while [[ "$from" -gt "$to" ]]; do
-    algo_swap_keep_focus -s ":.$from" -t ":.$((from - 1))"
-    from=$((from - 1))
-  done
-  while [[ "$from" -lt "$to" ]]; do
-    algo_swap_keep_focus -s ":.$from" -t ":.$((from + 1))"
-    from=$((from + 1))
-  done
-}
-
 algo_relayout() {
   local win n mfact nmaster pbase
   win=$(mosaic_resolve_window "${1:-}")
@@ -181,13 +162,13 @@ algo_promote() {
 
   if [[ "$idx" -eq "$pbase" ]]; then
     if [[ "$nmaster" -gt 1 ]]; then
-      algo_swap_keep_focus -s ":.$pbase" -t ":.$((pbase + 1))"
+      mosaic_swap_keep_focus -s ":.$pbase" -t ":.$((pbase + 1))"
     else
       stack_top=$((pbase + nmaster))
-      [[ "$stack_top" -ne "$pbase" ]] && algo_swap_keep_focus -s ":.$pbase" -t ":.$stack_top"
+      [[ "$stack_top" -ne "$pbase" ]] && mosaic_swap_keep_focus -s ":.$pbase" -t ":.$stack_top"
     fi
   else
-    algo_bubble_keep_focus "$idx" "$pbase"
+    mosaic_bubble_keep_focus "$idx" "$pbase"
   fi
   algo_relayout
 }

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -185,6 +185,25 @@ mosaic_current_pane_base() {
   tmux display-message -p '#{e|+|:0,#{?pane-base-index,#{pane-base-index},0}}'
 }
 
+mosaic_swap_keep_focus() {
+  local pid
+  pid=$(tmux display-message -p '#{pane_id}')
+  tmux swap-pane "$@"
+  tmux select-pane -t "$pid"
+}
+
+mosaic_bubble_keep_focus() {
+  local from="$1" to="$2"
+  while [[ "$from" -gt "$to" ]]; do
+    mosaic_swap_keep_focus -s ":.$from" -t ":.$((from - 1))"
+    from=$((from - 1))
+  done
+  while [[ "$from" -lt "$to" ]]; do
+    mosaic_swap_keep_focus -s ":.$from" -t ":.$((from + 1))"
+    from=$((from + 1))
+  done
+}
+
 mosaic_fibonacci_variant() {
   if declare -f algo_fibonacci_variant >/dev/null 2>&1; then
     algo_fibonacci_variant
@@ -357,21 +376,6 @@ mosaic_fibonacci_apply_layout() {
   tmux select-layout -t "$win" "$(mosaic_fibonacci_layout_checksum "$body"),$body" 2>/dev/null || true
 }
 
-mosaic_fibonacci_swap_keep_focus() {
-  local pid
-  pid=$(tmux display-message -p '#{pane_id}')
-  tmux swap-pane "$@"
-  tmux select-pane -t "$pid"
-}
-
-mosaic_fibonacci_bubble_keep_focus() {
-  local from="$1" to="$2"
-  while [[ "$from" -gt "$to" ]]; do
-    mosaic_fibonacci_swap_keep_focus -s ":.$from" -t ":.$((from - 1))"
-    from=$((from - 1))
-  done
-}
-
 mosaic_fibonacci_relayout() {
   local variant win n mfact pbase
   variant=$(mosaic_fibonacci_variant)
@@ -396,9 +400,9 @@ mosaic_fibonacci_promote() {
   [[ "$n" -le 1 ]] && return 0
 
   if [[ "$idx" -eq "$pbase" ]]; then
-    mosaic_fibonacci_swap_keep_focus -s ":.$pbase" -t ":.$((pbase + 1))"
+    mosaic_swap_keep_focus -s ":.$pbase" -t ":.$((pbase + 1))"
   else
-    mosaic_fibonacci_bubble_keep_focus "$idx" "$pbase"
+    mosaic_bubble_keep_focus "$idx" "$pbase"
   fi
   mosaic_fibonacci_relayout
 }


### PR DESCRIPTION
## Problem

Focus-preserving pane swap and bubble logic is duplicated across the master-style layouts and the Fibonacci promote path, which makes `promote` behavior harder to keep consistent.

## Solution

Add shared `mosaic_swap_keep_focus` and `mosaic_bubble_keep_focus` helpers in `scripts/helpers.sh`, switch the affected layouts to use them, and remove the duplicated per-layout implementations.