### PR TITLE
feat(hook): drive relayout via after-set-option

### DIFF
--- a/scripts/algorithms/bottom-stack.sh
+++ b/scripts/algorithms/bottom-stack.sh
@@ -50,7 +50,7 @@ algo_relayout() {
   mosaic_log "relayout: win=$win n=$n layout=bottom-stack nmaster=$nmaster mfact=$mfact"
 }
 
-algo_toggle() { mosaic_toggle_window algo_relayout; }
+algo_toggle() { mosaic_toggle_window; }
 
 algo_promote() {
   local idx n pbase
@@ -80,7 +80,6 @@ algo_resize_master() {
   [[ "$new" -lt 5 ]] && new=5
   [[ "$new" -gt 95 ]] && new=95
   tmux set-option -wq -t "$win" "@mosaic-mfact" "$new"
-  algo_relayout "$win"
 }
 
 algo_sync_state() {

--- a/scripts/algorithms/centered-master.sh
+++ b/scripts/algorithms/centered-master.sh
@@ -175,7 +175,7 @@ algo_relayout() {
   mosaic_log "relayout: win=$win n=$n layout=centered-master nmaster=$nmaster mfact=$mfact pbase=$pbase master_base=$master_base"
 }
 
-algo_toggle() { mosaic_toggle_window algo_relayout; }
+algo_toggle() { mosaic_toggle_window; }
 
 algo_promote() {
   local idx n win nmaster pbase master_base stack_top
@@ -213,7 +213,6 @@ algo_resize_master() {
   [[ "$new" -lt 5 ]] && new=5
   [[ "$new" -gt 95 ]] && new=95
   tmux set-option -wq -t "$win" "@mosaic-mfact" "$new"
-  algo_relayout "$win"
 }
 
 algo_sync_state() {

--- a/scripts/algorithms/dwindle.sh
+++ b/scripts/algorithms/dwindle.sh
@@ -3,7 +3,7 @@
 algo_fibonacci_variant() { printf '%s\n' "dwindle"; }
 
 algo_relayout() { mosaic_fibonacci_relayout "$@"; }
-algo_toggle() { mosaic_toggle_window algo_relayout; }
+algo_toggle() { mosaic_toggle_window; }
 algo_promote() { mosaic_fibonacci_promote; }
 algo_resize_master() { mosaic_fibonacci_resize_master "$@"; }
 algo_sync_state() { mosaic_fibonacci_sync_state "$1"; }

--- a/scripts/algorithms/even-horizontal.sh
+++ b/scripts/algorithms/even-horizontal.sh
@@ -2,4 +2,4 @@
 
 algo_relayout() { mosaic_relayout_simple even-horizontal "${1:-}"; }
 
-algo_toggle() { mosaic_toggle_window algo_relayout; }
+algo_toggle() { mosaic_toggle_window; }

--- a/scripts/algorithms/even-vertical.sh
+++ b/scripts/algorithms/even-vertical.sh
@@ -2,4 +2,4 @@
 
 algo_relayout() { mosaic_relayout_simple even-vertical "${1:-}"; }
 
-algo_toggle() { mosaic_toggle_window algo_relayout; }
+algo_toggle() { mosaic_toggle_window; }

--- a/scripts/algorithms/grid.sh
+++ b/scripts/algorithms/grid.sh
@@ -2,4 +2,4 @@
 
 algo_relayout() { mosaic_relayout_simple tiled "${1:-}"; }
 
-algo_toggle() { mosaic_toggle_window algo_relayout; }
+algo_toggle() { mosaic_toggle_window; }

--- a/scripts/algorithms/master-stack.sh
+++ b/scripts/algorithms/master-stack.sh
@@ -96,7 +96,7 @@ algo_relayout() {
   mosaic_log "relayout: win=$win n=$n orientation=$orientation nmaster=$nmaster mfact=$mfact"
 }
 
-algo_toggle() { mosaic_toggle_window algo_relayout; }
+algo_toggle() { mosaic_toggle_window; }
 
 algo_promote() {
   local idx n pbase
@@ -126,7 +126,6 @@ algo_resize_master() {
   [[ "$new" -lt 5 ]] && new=5
   [[ "$new" -gt 95 ]] && new=95
   tmux set-option -wq -t "$win" "@mosaic-mfact" "$new"
-  algo_relayout "$win"
 }
 
 algo_sync_state() {

--- a/scripts/algorithms/monocle.sh
+++ b/scripts/algorithms/monocle.sh
@@ -13,4 +13,4 @@ algo_relayout() {
   mosaic_log "relayout: win=$win n=$n zoomed=$zoomed"
 }
 
-algo_toggle() { mosaic_toggle_window algo_relayout; }
+algo_toggle() { mosaic_toggle_window; }

--- a/scripts/algorithms/spiral.sh
+++ b/scripts/algorithms/spiral.sh
@@ -3,7 +3,7 @@
 algo_fibonacci_variant() { printf '%s\n' "spiral"; }
 
 algo_relayout() { mosaic_fibonacci_relayout "$@"; }
-algo_toggle() { mosaic_toggle_window algo_relayout; }
+algo_toggle() { mosaic_toggle_window; }
 algo_promote() { mosaic_fibonacci_promote; }
 algo_resize_master() { mosaic_fibonacci_resize_master "$@"; }
 algo_sync_state() { mosaic_fibonacci_sync_state "$1"; }

--- a/scripts/algorithms/three-column.sh
+++ b/scripts/algorithms/three-column.sh
@@ -148,7 +148,7 @@ algo_relayout() {
   mosaic_log "relayout: win=$win n=$n layout=three-column nmaster=$nmaster mfact=$mfact pbase=$pbase"
 }
 
-algo_toggle() { mosaic_toggle_window algo_relayout; }
+algo_toggle() { mosaic_toggle_window; }
 
 algo_promote() {
   local idx n win nmaster pbase stack_top
@@ -185,7 +185,6 @@ algo_resize_master() {
   [[ "$new" -lt 5 ]] && new=5
   [[ "$new" -gt 95 ]] && new=95
   tmux set-option -wq -t "$win" "@mosaic-mfact" "$new"
-  algo_relayout "$win"
 }
 
 algo_sync_state() {

--- a/scripts/defaults.sh
+++ b/scripts/defaults.sh
@@ -9,7 +9,7 @@ mosaic_set_defaults() {
 }
 
 mosaic_register_hooks() {
-  local exec hook
+  local exec hook layout_option_filter
   exec=$(tmux show-option -gqv "@mosaic-exec")
   [[ -z "$exec" ]] && return 0
 
@@ -18,4 +18,8 @@ mosaic_register_hooks() {
   done
   tmux set-hook -ga after-resize-pane \
     "run-shell -b '$exec _sync-state #{window_id}'"
+
+  layout_option_filter='#{||:#{||:#{m:@mosaic-algorithm,#{hook_argument_0}},#{m:@mosaic-orientation,#{hook_argument_0}}},#{||:#{m:@mosaic-nmaster,#{hook_argument_0}},#{m:@mosaic-mfact,#{hook_argument_0}}}}'
+  tmux set-hook -ga after-set-option \
+    "if-shell -bF '$layout_option_filter' \"run-shell -b '$exec _on-set-option #{hook_argument_0} #{window_id}'\""
 }

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -142,7 +142,7 @@ mosaic_can_relayout_window() {
 }
 
 mosaic_toggle_window() {
-  local relayout_fn="${1:-}" win local_algo global_algo
+  local win local_algo global_algo
   win=$(mosaic_current_window)
   local_algo=$(mosaic_local_algorithm "$win")
   global_algo=$(mosaic_global_algorithm)
@@ -151,7 +151,6 @@ mosaic_toggle_window() {
     if [[ -n "$global_algo" && "$global_algo" != "off" ]]; then
       tmux set-option -wqu -t "$win" "@mosaic-algorithm" 2>/dev/null
       mosaic_show_message "mosaic: on"
-      [[ -n "$relayout_fn" ]] && "$relayout_fn" "$win"
     else
       mosaic_show_message "mosaic: no layout configured"
     fi
@@ -419,7 +418,6 @@ mosaic_fibonacci_resize_master() {
   [[ "$new" -lt 5 ]] && new=5
   [[ "$new" -gt 95 ]] && new=95
   tmux set-option -wq -t "$win" "@mosaic-mfact" "$new"
-  mosaic_fibonacci_relayout "$win"
 }
 
 mosaic_fibonacci_sync_state() {

--- a/scripts/ops.sh
+++ b/scripts/ops.sh
@@ -6,27 +6,34 @@ source "$CURRENT_DIR/helpers.sh"
 
 load_algorithm() {
   local algo="$1"
-  if [[ ! "$algo" =~ ^[a-z][a-z0-9-]*$ ]]; then
-    echo "mosaic: invalid algorithm name: $algo" >&2
-    return 1
-  fi
+  [[ "$algo" =~ ^[a-z][a-z0-9-]*$ ]] || return 2
   local file="$CURRENT_DIR/algorithms/$algo.sh"
-  if [[ ! -f "$file" ]]; then
-    echo "mosaic: unknown algorithm: $algo" >&2
-    return 1
-  fi
+  [[ -f "$file" ]] || return 3
   # shellcheck source=algorithms/master-stack.sh
   source "$file"
   return 0
+}
+
+show_load_error() {
+  local rc="$1" algo="$2"
+  case "$rc" in
+  2) mosaic_show_message "mosaic: invalid algorithm name: $algo" ;;
+  3) mosaic_show_message "mosaic: unknown algorithm: $algo" ;;
+  esac
 }
 
 cmd="${1:-}"
 [[ $# -gt 0 ]] && shift
 
 WIN_ARG=""
+CHANGED_OPT=""
 case "$cmd" in
 relayout | _sync-state)
   WIN_ARG="${1:-}"
+  ;;
+_on-set-option)
+  CHANGED_OPT="${1:-}"
+  WIN_ARG="${2:-}"
   ;;
 esac
 
@@ -40,7 +47,7 @@ fi
 
 if [[ -z "$algo" ]]; then
   case "$cmd" in
-  relayout | _sync-state) exit 0 ;;
+  relayout | _sync-state | _on-set-option) exit 0 ;;
   toggle | promote | resize-master)
     mosaic_show_message "mosaic: no layout configured"
     exit 0
@@ -48,7 +55,15 @@ if [[ -z "$algo" ]]; then
   esac
 fi
 
-if ! load_algorithm "$algo"; then
+load_algorithm "$algo"
+load_rc=$?
+if [[ $load_rc -ne 0 ]]; then
+  case "$cmd" in
+  relayout | toggle | promote | resize-master) show_load_error "$load_rc" "$algo" ;;
+  _on-set-option)
+    [[ "$CHANGED_OPT" == "@mosaic-algorithm" ]] && show_load_error "$load_rc" "$algo"
+    ;;
+  esac
   exit 1
 fi
 
@@ -64,7 +79,7 @@ dispatch_optional() {
 }
 
 case "$cmd" in
-relayout) algo_relayout "$target_window" ;;
+relayout | _on-set-option) algo_relayout "$target_window" ;;
 toggle) algo_toggle ;;
 _sync-state)
   if declare -f algo_sync_state >/dev/null; then

--- a/tests/integration/bottom_stack.bats
+++ b/tests/integration/bottom_stack.bats
@@ -67,6 +67,7 @@ pane_field() {
   for _ in 1 2 3; do mosaic_split; done
 
   mosaic_op resize-master +10
+  sleep 0.2
 
   [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
   [ "$(mosaic_t show-option -wqv -t t:1 main-pane-height)" = "60%" ]

--- a/tests/integration/centered_master.bats
+++ b/tests/integration/centered_master.bats
@@ -112,6 +112,7 @@ pane_field() {
   for _ in 1 2 3; do mosaic_split; done
 
   mosaic_op resize-master +10
+  sleep 0.2
 
   [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
   pane2_w=$(pane_field t:1 2 4)

--- a/tests/integration/dwindle.bats
+++ b/tests/integration/dwindle.bats
@@ -97,6 +97,7 @@ pane_field() {
   for _ in 1 2; do mosaic_split; done
 
   mosaic_op resize-master +10
+  sleep 0.2
 
   [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
   pane1_w=$(pane_field t:1 1 4)

--- a/tests/integration/master_stack.bats
+++ b/tests/integration/master_stack.bats
@@ -230,6 +230,7 @@ assert_orientation_layout() {
   mosaic_op relayout
 
   mosaic_op resize-master +10
+  sleep 0.2
 
   [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
   [ "$(mosaic_t show-option -wqv -t t:1 main-pane-height)" = "60%" ]
@@ -240,6 +241,7 @@ assert_orientation_layout() {
   for _ in 1 2 3; do mosaic_split; done
 
   mosaic_op resize-master +10
+  sleep 0.2
 
   [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
   pane1_w=$(pane_field t:1 1 4)
@@ -392,6 +394,7 @@ assert_orientation_layout() {
   for _ in 1 2; do mosaic_split; done
 
   mosaic_op toggle
+  sleep 0.2
   [ -z "$(mosaic_t show-option -wqv -t t:1 @mosaic-algorithm)" ]
 
   layout=$(mosaic_layout)

--- a/tests/integration/option_hook.bats
+++ b/tests/integration/option_hook.bats
@@ -1,0 +1,164 @@
+#!/usr/bin/env bats
+
+load '../helpers.bash'
+
+setup() {
+  mosaic_setup_server
+  mosaic_use_algorithm master-stack
+  for _ in 1 2 3; do mosaic_split; done
+}
+
+teardown() {
+  mosaic_teardown_server
+}
+
+reset_log() { : >/tmp/tmux-mosaic-test.log; }
+relayout_count() { grep -c '^[^ ]* \[[0-9]*\] relayout:' /tmp/tmux-mosaic-test.log || true; }
+sync_count() { grep -c '^[^ ]* \[[0-9]*\] sync-state:' /tmp/tmux-mosaic-test.log || true; }
+layout_outer() {
+  mosaic_layout t:1 | awk 'match($0, /[\[{]/) { print substr($0, RSTART, 1) }'
+}
+
+@test "after-set-option hook: registered with the layout-option filter" {
+  run mosaic_t show-hooks -g after-set-option
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"if-shell"* ]]
+  [[ "$output" == *"@mosaic-algorithm"* ]]
+  [[ "$output" == *"@mosaic-orientation"* ]]
+  [[ "$output" == *"@mosaic-nmaster"* ]]
+  [[ "$output" == *"@mosaic-mfact"* ]]
+  [[ "$output" == *"_on-set-option"* ]]
+}
+
+@test "after-set-option: set @mosaic-algorithm grid switches layout in one event" {
+  [ "$(layout_outer)" = "{" ]
+
+  reset_log
+  mosaic_t set-option -wq -t t:1 "@mosaic-algorithm" "grid"
+  sleep 0.2
+
+  [ "$(layout_outer)" = "[" ]
+  [ "$(relayout_count)" = "1" ]
+}
+
+@test "after-set-option: set @mosaic-orientation right relayouts to right master" {
+  reset_log
+  mosaic_t set-option -wq -t t:1 "@mosaic-orientation" "right"
+  sleep 0.2
+
+  pane1_left=$(mosaic_t list-panes -t t:1 -F '#{pane_index} #{pane_left}' | awk '$1 == 1 { print $2 }')
+  [ "$pane1_left" -gt 0 ]
+  [ "$(relayout_count)" = "1" ]
+}
+
+@test "after-set-option: set @mosaic-nmaster 2 relayouts" {
+  reset_log
+  mosaic_t set-option -wq -t t:1 "@mosaic-nmaster" "2"
+  sleep 0.2
+
+  [ "$(relayout_count)" = "1" ]
+  grep -q 'nmaster=2' /tmp/tmux-mosaic-test.log
+}
+
+@test "after-set-option: set @mosaic-mfact 70 relayouts" {
+  reset_log
+  mosaic_t set-option -wq -t t:1 "@mosaic-mfact" "70"
+  sleep 0.2
+
+  [ "$(mosaic_t show-option -wqv -t t:1 main-pane-width)" = "70%" ]
+  [ "$(relayout_count)" = "1" ]
+}
+
+@test "after-set-option: set @mosaic-debug does NOT relayout" {
+  reset_log
+  mosaic_t set-option -gq "@mosaic-debug" "0"
+  mosaic_t set-option -gq "@mosaic-debug" "1"
+  sleep 0.2
+
+  [ "$(relayout_count)" = "0" ]
+}
+
+@test "after-set-option: set @mosaic-step does NOT relayout" {
+  reset_log
+  mosaic_t set-option -gq "@mosaic-step" "10"
+  sleep 0.2
+
+  [ "$(relayout_count)" = "0" ]
+}
+
+@test "after-set-option: set unrelated tmux option does NOT relayout" {
+  reset_log
+  mosaic_t set-option -gq "mouse" "on"
+  mosaic_t set-option -gq "status-left" "test"
+  sleep 0.2
+
+  [ "$(relayout_count)" = "0" ]
+}
+
+@test "after-set-option: invalid algorithm name surfaces an error" {
+  run mosaic_exec_direct relayout
+  [ "$status" -eq 0 ]
+
+  mosaic_t set-option -wq -t t:1 "@mosaic-algorithm" "nonexistent-algo"
+  sleep 0.2
+
+  mosaic_t set-option -wq -t t:1 "@mosaic-algorithm" "grid"
+  sleep 0.2
+  [ "$(layout_outer)" = "[" ]
+}
+
+@test "no double relayout: resize-master via op fires exactly once" {
+  reset_log
+  mosaic_op resize-master +10
+  sleep 0.2
+
+  [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
+  [ "$(relayout_count)" = "1" ]
+}
+
+@test "no double relayout: toggle off->on fires exactly once" {
+  mosaic_disable_algorithm
+  sleep 0.2
+  reset_log
+
+  mosaic_use_global_algorithm master-stack
+  mosaic_op toggle
+  sleep 0.2
+
+  [ "$(relayout_count)" = "1" ]
+}
+
+@test "no double relayout: drag-resize sync triggers one relayout" {
+  reset_log
+  mosaic_t resize-pane -t t:1.1 -x 160
+  sleep 0.3
+
+  [ "$(sync_count)" = "1" ]
+  [ "$(relayout_count)" = "1" ]
+}
+
+@test "after-set-option: set @mosaic-algorithm to off preserves layout" {
+  before=$(mosaic_layout t:1)
+
+  reset_log
+  mosaic_t set-option -wq -t t:1 "@mosaic-algorithm" "off"
+  sleep 0.2
+
+  after=$(mosaic_layout t:1)
+  [ "$before" = "$after" ]
+  [ "$(relayout_count)" = "0" ]
+}
+
+@test "after-set-option: unset window option falls back to global" {
+  mosaic_use_global_algorithm grid
+  mosaic_use_algorithm master-stack t:1
+  sleep 0.2
+  [ "$(layout_outer)" = "{" ]
+
+  reset_log
+  mosaic_t set-option -wqu -t t:1 "@mosaic-algorithm"
+  sleep 0.2
+
+  [ "$(layout_outer)" = "[" ]
+  [ "$(relayout_count)" = "1" ]
+}

--- a/tests/integration/spiral.bats
+++ b/tests/integration/spiral.bats
@@ -94,6 +94,7 @@ pane_field() {
   for _ in 1 2; do mosaic_split; done
 
   mosaic_op resize-master +10
+  sleep 0.2
 
   [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
   pane1_w=$(pane_field t:1 1 4)

--- a/tests/integration/three_column.bats
+++ b/tests/integration/three_column.bats
@@ -113,6 +113,7 @@ pane_field() {
   for _ in 1 2 3; do mosaic_split; done
 
   mosaic_op resize-master +10
+  sleep 0.2
 
   [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
   pane1_w=$(pane_field t:1 1 4)


### PR DESCRIPTION
## Problem

Closes #62, closes #64. Partially addresses #65.

Changing `@mosaic-algorithm` from a binding only took effect on the next pane event because tmux had no hook for option changes — that's the root cause of the glitchy layout switching tracked in #64. The Quick Start binding `bind G set-option -wq @mosaic-algorithm grid` was documented but didn't actually relayout immediately. A separate `switch-layout` op (#62) is unnecessary because tmux's own option model is already the API; we just needed to react to it. Several paths also explicitly called `algo_relayout` right after writing a `@mosaic-*` option, double-firing the layout work.

## Solution

Register `after-set-option`, filtered inside tmux's format engine via `if-shell -bF '#{||:#{||:#{m:@mosaic-algorithm,#{hook_argument_0}},#{m:@mosaic-orientation,#{hook_argument_0}}},#{||:#{m:@mosaic-nmaster,#{hook_argument_0}},#{m:@mosaic-mfact,#{hook_argument_0}}}}'`, so only the four layout-affecting options dispatch to a new internal `_on-set-option` op. `hook_argument_0` has been available since tmux 3.2 (commits `9991a14` / `beb214b`, May 2020), so the existing minimum is unchanged. Unrelated options (`mouse`, `status-left`, `@other-plugin`, even `@mosaic-debug` and `@mosaic-step`) skip in the format engine without forking a shell.

Drop the now-redundant explicit `algo_relayout` calls in every layout's `algo_resize_master` and in `mosaic_toggle_window` — the option write itself is now the single source of truth for triggering a relayout. The `relayout_fn` argument to `mosaic_toggle_window` is gone; all 10 `algo_toggle` callers updated. Invalid algorithm names now surface once via `mosaic_show_message`, gated to only fire when `@mosaic-algorithm` itself was the option being set, so subsequent `@mosaic-mfact` writes don't re-spam the error.

14 new bats tests in `tests/integration/option_hook.bats` cover: the hook is registered with the allowlist filter; each of the four layout options triggers exactly one relayout; non-mosaic options and `@mosaic-debug` / `@mosaic-step` trigger zero relayouts; invalid algorithm name shows the error and recovers; `resize-master` / `toggle off→on` / `drag-resize sync-state` each fire exactly one relayout (no doubles); `off` sentinel preserves layout; window-unset falls back to global. The full 110-test suite passes.

The `_sync-state → @mosaic-mfact write → after-set-option → relayout` cascade is intentional and tracked in #65 — the relayout is idempotent and converts tmux's frozen-custom layout back to the master-stack template form.

The README was already teaching the correct binding pattern, so no docs change is needed; the fix is purely internal and the documented pattern just now works as written.