### PR TITLE
perf(hook): cache layout fingerprint to skip no-op relayouts

### DIFF
--- a/scripts/algorithms/bottom-stack.sh
+++ b/scripts/algorithms/bottom-stack.sh
@@ -104,6 +104,6 @@ algo_sync_state() {
   [[ "$pct" -lt 5 ]] && pct=5
   [[ "$pct" -gt 95 ]] && pct=95
 
-  tmux set-option -wq -t "$win" "@mosaic-mfact" "$pct"
+  mosaic_sync_mfact "$win" "$pct"
   mosaic_log "sync-state: win=$win layout=bottom-stack pane_size=$pane_size window_size=$window_size pct=$pct"
 }

--- a/scripts/algorithms/centered-master.sh
+++ b/scripts/algorithms/centered-master.sh
@@ -238,6 +238,6 @@ algo_sync_state() {
   [[ "$pct" -lt 5 ]] && pct=5
   [[ "$pct" -gt 95 ]] && pct=95
 
-  tmux set-option -wq -t "$win" "@mosaic-mfact" "$pct"
+  mosaic_sync_mfact "$win" "$pct"
   mosaic_log "sync-state: win=$win layout=centered-master master_base=$master_base pane_size=$pane_size window_size=$window_size pct=$pct"
 }

--- a/scripts/algorithms/master-stack.sh
+++ b/scripts/algorithms/master-stack.sh
@@ -159,6 +159,6 @@ algo_sync_state() {
   [[ "$pct" -lt 5 ]] && pct=5
   [[ "$pct" -gt 95 ]] && pct=95
 
-  tmux set-option -wq -t "$win" "@mosaic-mfact" "$pct"
+  mosaic_sync_mfact "$win" "$pct"
   mosaic_log "sync-state: win=$win orientation=$orientation pane_size=$pane_size window_size=$window_size pct=$pct"
 }

--- a/scripts/algorithms/three-column.sh
+++ b/scripts/algorithms/three-column.sh
@@ -209,6 +209,6 @@ algo_sync_state() {
   [[ "$pct" -lt 5 ]] && pct=5
   [[ "$pct" -gt 95 ]] && pct=95
 
-  tmux set-option -wq -t "$win" "@mosaic-mfact" "$pct"
+  mosaic_sync_mfact "$win" "$pct"
   mosaic_log "sync-state: win=$win layout=three-column pbase=$pbase pane_size=$pane_size window_size=$window_size pct=$pct"
 }

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -121,6 +121,36 @@ mosaic_first_client() {
   tmux list-clients -F '#{client_name}' 2>/dev/null | head -n1
 }
 
+mosaic_compute_fingerprint() {
+  local win="$1" algo="$2"
+  local n mfact nmaster orientation window_w window_h zoomed
+  n=$(mosaic_window_pane_count "$win")
+  mfact=$(mosaic_get_w "@mosaic-mfact" "50" "$win")
+  nmaster=$(mosaic_get_w "@mosaic-nmaster" "1" "$win")
+  orientation=$(mosaic_get_w "@mosaic-orientation" "left" "$win")
+  window_w=$(tmux display-message -p -t "$win" '#{window_width}' 2>/dev/null)
+  window_h=$(tmux display-message -p -t "$win" '#{window_height}' 2>/dev/null)
+  zoomed=$(mosaic_window_zoomed "$win")
+  printf '%s|%s|%s|%s|%s|%s|%s|%s\n' \
+    "$algo" "$n" "$mfact" "$nmaster" "$orientation" "$window_w" "$window_h" "$zoomed"
+}
+
+mosaic_fingerprint_get() {
+  mosaic_get_w_raw "@mosaic-_fingerprint" "${1:-}"
+}
+
+mosaic_fingerprint_set() {
+  local win="$1" fp="$2"
+  tmux set-option -wq -t "$win" "@mosaic-_fingerprint" "$fp"
+}
+
+mosaic_sync_mfact() {
+  local win="$1" pct="$2" current
+  current=$(mosaic_get_w_raw "@mosaic-mfact" "$win")
+  [[ "$current" == "$pct" ]] && return 0
+  tmux set-option -wq -t "$win" "@mosaic-mfact" "$pct"
+}
+
 mosaic_show_message() {
   local message="$*" client
   client=$(tmux display-message -p '#{client_name}' 2>/dev/null)
@@ -441,7 +471,7 @@ mosaic_fibonacci_sync_state() {
   [[ "$pct" -lt 5 ]] && pct=5
   [[ "$pct" -gt 95 ]] && pct=95
 
-  tmux set-option -wq -t "$win" "@mosaic-mfact" "$pct"
+  mosaic_sync_mfact "$win" "$pct"
   mosaic_log "sync-state: win=$win layout=$variant pbase=$pbase pane_size=$pane_size window_size=$window_size pct=$pct"
 }
 

--- a/scripts/ops.sh
+++ b/scripts/ops.sh
@@ -47,7 +47,11 @@ fi
 
 if [[ -z "$algo" ]]; then
   case "$cmd" in
-  relayout | _sync-state | _on-set-option) exit 0 ;;
+  _on-set-option)
+    tmux set-option -wqu -t "$target_window" "@mosaic-_fingerprint" 2>/dev/null
+    exit 0
+    ;;
+  relayout | _sync-state) exit 0 ;;
   toggle | promote | resize-master)
     mosaic_show_message "mosaic: no layout configured"
     exit 0
@@ -65,6 +69,14 @@ if [[ $load_rc -ne 0 ]]; then
     ;;
   esac
   exit 1
+fi
+
+if [[ "$cmd" == "_on-set-option" ]]; then
+  fingerprint=$(mosaic_compute_fingerprint "$target_window" "$algo")
+  cached=$(mosaic_fingerprint_get "$target_window")
+  if [[ -n "$cached" && "$cached" == "$fingerprint" ]]; then
+    exit 0
+  fi
 fi
 
 dispatch_optional() {
@@ -95,5 +107,12 @@ resize-master) dispatch_optional algo_resize_master "$@" ;;
 *)
   echo "mosaic: unknown op: $cmd" >&2
   exit 1
+  ;;
+esac
+
+case "$cmd" in
+relayout | _on-set-option | promote)
+  mosaic_fingerprint_set "$target_window" \
+    "$(mosaic_compute_fingerprint "$target_window" "$algo")"
   ;;
 esac

--- a/tests/integration/option_hook.bats
+++ b/tests/integration/option_hook.bats
@@ -162,3 +162,69 @@ layout_outer() {
   [ "$(layout_outer)" = "[" ]
   [ "$(relayout_count)" = "1" ]
 }
+
+@test "fingerprint cache: setting @mosaic-mfact to its current value triggers zero relayouts" {
+  mosaic_t set-option -wq -t t:1 "@mosaic-mfact" "70"
+  sleep 0.2
+  reset_log
+
+  mosaic_t set-option -wq -t t:1 "@mosaic-mfact" "70"
+  sleep 0.2
+
+  [ "$(relayout_count)" = "0" ]
+}
+
+@test "fingerprint cache: setting @mosaic-orientation to its current value triggers zero relayouts" {
+  mosaic_t set-option -wq -t t:1 "@mosaic-orientation" "right"
+  sleep 0.2
+  reset_log
+
+  mosaic_t set-option -wq -t t:1 "@mosaic-orientation" "right"
+  sleep 0.2
+
+  [ "$(relayout_count)" = "0" ]
+}
+
+@test "fingerprint cache: setting @mosaic-algorithm to its current value triggers zero relayouts" {
+  reset_log
+
+  mosaic_t set-option -wq -t t:1 "@mosaic-algorithm" "master-stack"
+  sleep 0.2
+
+  [ "$(relayout_count)" = "0" ]
+}
+
+@test "fingerprint cache: two distinct orientation changes fire two relayouts" {
+  reset_log
+  mosaic_t set-option -wq -t t:1 "@mosaic-orientation" "right"
+  sleep 0.2
+  mosaic_t set-option -wq -t t:1 "@mosaic-orientation" "left"
+  sleep 0.2
+
+  [ "$(relayout_count)" = "2" ]
+}
+
+@test "fingerprint cache: cleared on transition to off so re-enable always relayouts" {
+  reset_log
+
+  mosaic_disable_algorithm
+  sleep 0.2
+  [ -z "$(mosaic_t show-option -wqv -t t:1 @mosaic-_fingerprint)" ]
+
+  mosaic_use_algorithm master-stack
+  sleep 0.2
+  [ "$(relayout_count)" -ge "1" ]
+  [ -n "$(mosaic_t show-option -wqv -t t:1 @mosaic-_fingerprint)" ]
+}
+
+@test "sync short-circuit: drag-resize whose pct is unchanged does not write @mosaic-mfact" {
+  mosaic_t set-option -wq -t t:1 "@mosaic-mfact" "50"
+  sleep 0.2
+  reset_log
+
+  mosaic_t resize-pane -t t:1.1 -x 100
+  sleep 0.3
+
+  [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "50" ]
+  [ "$(relayout_count)" = "0" ]
+}


### PR DESCRIPTION
## Problem

Closes #65.

After #66 landed, `after-set-option` drove relayout for every write of `@mosaic-{algorithm,orientation,nmaster,mfact}`. That fixed the glitchy switching but introduced a different inefficiency: same-value writes still relayouted, drag-resize sync wrote `@mosaic-mfact` even when the synced pct was unchanged, and the 8-fold fan-out of a global `set-option` produced 8 idempotent `select-layout` calls instead of one. The PR description for #66 explicitly flagged this and tracked it under #65.

## Solution

Two complementary mechanisms.

**Fingerprint cache.** Each window now stores a private `@mosaic-_fingerprint` option containing `algo|n_panes|mfact|nmaster|orientation|window_w|window_h|zoomed`. `_on-set-option` computes the new fingerprint, compares against the cached one, and exits early on a match. Every successful relayout (`relayout`, `_on-set-option`, `promote`) writes the new fingerprint. Transitions to no-algo — the `off` sentinel or a full unset — clear the cache so a subsequent re-enable is always treated as a layout transition. The `if-shell` filter in `defaults.sh` is unchanged: `@mosaic-_fingerprint` is not in the four-option allowlist, so writing it does not re-enter the hook.

**Sync short-circuit.** A new `mosaic_sync_mfact` helper writes `@mosaic-mfact` only when the synced pct differs from the current value. All five `_sync-state` implementations (master-stack, bottom-stack, centered-master, three-column, and the Fibonacci helper used by spiral/dwindle) call it instead of writing unconditionally.

The `_sync-state → @mosaic-mfact write → after-set-option → relayout` chain still exists when the pct actually changes, which is the desired behavior. When the pct is unchanged the chain is cut at the source.

Pane order is deliberately excluded from the fingerprint. `promote` and `swap-pane` change order but always go through explicit `algo_relayout`, which bypasses the cache by design and updates the fingerprint after.

## Tests

Six new bats cases in `tests/integration/option_hook.bats`:

- `setting @mosaic-mfact / @mosaic-orientation / @mosaic-algorithm to its current value triggers zero relayouts` (3 cases)
- `two distinct orientation changes fire two relayouts` (cache does not over-skip when state actually changed)
- `cleared on transition to off so re-enable always relayouts` (correctness across off/on cycles)
- `drag-resize whose pct is unchanged does not write @mosaic-mfact` (sync short-circuit)

The full 116-test suite is green, including all `no double relayout` tests from #66.

## Out of scope

While building this I confirmed a separate pre-existing bug — `mosaic_get_w` uses `show -wqv` without `-A`, so `set -gwq @mosaic-orientation right` (the documented Quick Start pattern) does not actually take effect. Filed as #67. This PR sticks to the cache and does not touch the helper inheritance behavior.