### PR TITLE
fix(helpers): honor -gw inheritance for orientation, nmaster, mfact

### DIFF
--- a/scripts/algorithms/bottom-stack.sh
+++ b/scripts/algorithms/bottom-stack.sh
@@ -10,17 +10,6 @@ algo_apply_layout() {
   tmux select-layout -t "$win" main-horizontal 2>/dev/null || true
 }
 
-algo_mfact_for() {
-  local win="$1"
-  local val
-  val=$(tmux show-option -wqv -t "$win" "@mosaic-mfact" 2>/dev/null)
-  [[ -n "$val" ]] && {
-    echo "$val"
-    return
-  }
-  mosaic_get "@mosaic-mfact" "50"
-}
-
 algo_join_extra_masters() {
   local win="$1" nmaster="$2" n="$3" pbase="$4"
   local idx
@@ -36,7 +25,7 @@ algo_relayout() {
   win=$(mosaic_resolve_window "${1:-}")
   n=$(mosaic_window_pane_count "$win")
   mosaic_can_relayout_window "$win" "$n" || return 0
-  mfact=$(algo_mfact_for "$win")
+  mfact=$(mosaic_mfact_for "$win")
   nmaster=$(mosaic_effective_nmaster "$win" "$n")
   pbase=$(algo_pane_base)
 
@@ -75,7 +64,7 @@ algo_resize_master() {
   fi
   local win cur new
   win=$(mosaic_current_window)
-  cur=$(algo_mfact_for "$win")
+  cur=$(mosaic_mfact_for "$win")
   new=$((cur + delta))
   [[ "$new" -lt 5 ]] && new=5
   [[ "$new" -gt 95 ]] && new=95

--- a/scripts/algorithms/centered-master.sh
+++ b/scripts/algorithms/centered-master.sh
@@ -4,17 +4,6 @@ algo_pane_count() { tmux display-message -p '#{window_panes}'; }
 algo_pane_index() { tmux display-message -p '#{pane_index}'; }
 algo_pane_base() { tmux display-message -p '#{e|+|:0,#{?pane-base-index,#{pane-base-index},0}}'; }
 
-algo_mfact_for() {
-  local win="$1"
-  local val
-  val=$(tmux show-option -wqv -t "$win" "@mosaic-mfact" 2>/dev/null)
-  [[ -n "$val" ]] && {
-    echo "$val"
-    return
-  }
-  mosaic_get "@mosaic-mfact" "50"
-}
-
 algo_layout_checksum() {
   local layout="$1" csum=0 i ch
   for ((i = 0; i < ${#layout}; i++)); do
@@ -165,7 +154,7 @@ algo_relayout() {
   win=$(mosaic_resolve_window "${1:-}")
   n=$(mosaic_window_pane_count "$win")
   mosaic_can_relayout_window "$win" "$n" || return 0
-  mfact=$(algo_mfact_for "$win")
+  mfact=$(mosaic_mfact_for "$win")
   nmaster=$(mosaic_effective_nmaster "$win" "$n")
   pbase=$(algo_pane_base)
   master_base=$(algo_master_base "$n" "$nmaster" "$pbase")
@@ -208,7 +197,7 @@ algo_resize_master() {
   fi
   local win cur new
   win=$(mosaic_current_window)
-  cur=$(algo_mfact_for "$win")
+  cur=$(mosaic_mfact_for "$win")
   new=$((cur + delta))
   [[ "$new" -lt 5 ]] && new=5
   [[ "$new" -gt 95 ]] && new=95

--- a/scripts/algorithms/master-stack.sh
+++ b/scripts/algorithms/master-stack.sh
@@ -54,17 +54,6 @@ algo_apply_layout() {
   tmux select-layout -t "$win" "$(algo_layout_for "$orientation")" 2>/dev/null || true
 }
 
-algo_mfact_for() {
-  local win="$1"
-  local val
-  val=$(tmux show-option -wqv -t "$win" "@mosaic-mfact" 2>/dev/null)
-  [[ -n "$val" ]] && {
-    echo "$val"
-    return
-  }
-  mosaic_get "@mosaic-mfact" "50"
-}
-
 algo_join_extra_masters() {
   local win="$1" orientation="$2" nmaster="$3" n="$4" pbase="$5"
   local flag idx
@@ -81,7 +70,7 @@ algo_relayout() {
   win=$(mosaic_resolve_window "${1:-}")
   n=$(mosaic_window_pane_count "$win")
   mosaic_can_relayout_window "$win" "$n" || return 0
-  mfact=$(algo_mfact_for "$win")
+  mfact=$(mosaic_mfact_for "$win")
   orientation=$(algo_orientation_for "$win")
   nmaster=$(mosaic_effective_nmaster "$win" "$n")
   pbase=$(algo_pane_base)
@@ -121,7 +110,7 @@ algo_resize_master() {
   fi
   local win cur new
   win=$(mosaic_current_window)
-  cur=$(algo_mfact_for "$win")
+  cur=$(mosaic_mfact_for "$win")
   new=$((cur + delta))
   [[ "$new" -lt 5 ]] && new=5
   [[ "$new" -gt 95 ]] && new=95

--- a/scripts/algorithms/three-column.sh
+++ b/scripts/algorithms/three-column.sh
@@ -4,17 +4,6 @@ algo_pane_count() { tmux display-message -p '#{window_panes}'; }
 algo_pane_index() { tmux display-message -p '#{pane_index}'; }
 algo_pane_base() { tmux display-message -p '#{e|+|:0,#{?pane-base-index,#{pane-base-index},0}}'; }
 
-algo_mfact_for() {
-  local win="$1"
-  local val
-  val=$(tmux show-option -wqv -t "$win" "@mosaic-mfact" 2>/dev/null)
-  [[ -n "$val" ]] && {
-    echo "$val"
-    return
-  }
-  mosaic_get "@mosaic-mfact" "50"
-}
-
 algo_layout_checksum() {
   local layout="$1" csum=0 i ch
   for ((i = 0; i < ${#layout}; i++)); do
@@ -139,7 +128,7 @@ algo_relayout() {
   win=$(mosaic_resolve_window "${1:-}")
   n=$(mosaic_window_pane_count "$win")
   mosaic_can_relayout_window "$win" "$n" || return 0
-  mfact=$(algo_mfact_for "$win")
+  mfact=$(mosaic_mfact_for "$win")
   nmaster=$(mosaic_effective_nmaster "$win" "$n")
   pbase=$(algo_pane_base)
 
@@ -180,7 +169,7 @@ algo_resize_master() {
   fi
   local win cur new
   win=$(mosaic_current_window)
-  cur=$(algo_mfact_for "$win")
+  cur=$(mosaic_mfact_for "$win")
   new=$((cur + delta))
   [[ "$new" -lt 5 ]] && new=5
   [[ "$new" -gt 95 ]] && new=95

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -11,9 +11,9 @@ mosaic_get_w() {
   local opt="$1" default="$2" target="${3:-}"
   local val
   if [[ -n "$target" ]]; then
-    val=$(tmux show-option -wqv -t "$target" "$opt" 2>/dev/null)
+    val=$(tmux show-option -wqvA -t "$target" "$opt" 2>/dev/null)
   else
-    val=$(tmux show-option -wqv "$opt" 2>/dev/null)
+    val=$(tmux show-option -wqvA "$opt" 2>/dev/null)
   fi
   printf '%s\n' "${val:-$default}"
 }
@@ -119,6 +119,16 @@ mosaic_effective_nmaster() {
 
 mosaic_first_client() {
   tmux list-clients -F '#{client_name}' 2>/dev/null | head -n1
+}
+
+mosaic_mfact_for() {
+  local win="$1" val
+  val=$(tmux show-option -wqvA -t "$win" "@mosaic-mfact" 2>/dev/null)
+  [[ -n "$val" ]] && {
+    printf '%s\n' "$val"
+    return
+  }
+  mosaic_get "@mosaic-mfact" "50"
 }
 
 mosaic_compute_fingerprint() {
@@ -239,16 +249,6 @@ mosaic_fibonacci_variant() {
   else
     printf '%s\n' "spiral"
   fi
-}
-
-mosaic_fibonacci_mfact_for() {
-  local win="$1" val
-  val=$(tmux show-option -wqv -t "$win" "@mosaic-mfact" 2>/dev/null)
-  [[ -n "$val" ]] && {
-    printf '%s\n' "$val"
-    return
-  }
-  mosaic_get "@mosaic-mfact" "50"
 }
 
 mosaic_fibonacci_layout_checksum() {
@@ -411,7 +411,7 @@ mosaic_fibonacci_relayout() {
   win=$(mosaic_resolve_window "${1:-}")
   n=$(mosaic_window_pane_count "$win")
   mosaic_can_relayout_window "$win" "$n" || return 0
-  mfact=$(mosaic_fibonacci_mfact_for "$win")
+  mfact=$(mosaic_mfact_for "$win")
   pbase=$(mosaic_current_pane_base)
 
   mosaic_fibonacci_apply_layout "$win" "$n" "$mfact"
@@ -443,7 +443,7 @@ mosaic_fibonacci_resize_master() {
   fi
   local win cur new
   win=$(mosaic_current_window)
-  cur=$(mosaic_fibonacci_mfact_for "$win")
+  cur=$(mosaic_mfact_for "$win")
   new=$((cur + delta))
   [[ "$new" -lt 5 ]] && new=5
   [[ "$new" -gt 95 ]] && new=95

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -91,3 +91,15 @@ mosaic_op() {
 mosaic_panes_summary() {
   mosaic_t list-panes -t "${1:-t:1}" -F '#{pane_index}:#{pane_id}' | paste -sd' '
 }
+
+mosaic_wait_until() {
+  local timeout_ms="${1:-2000}"
+  shift
+  local elapsed=0
+  while ! "$@" >/dev/null 2>&1; do
+    sleep 0.02
+    elapsed=$((elapsed + 20))
+    [[ "$elapsed" -ge "$timeout_ms" ]] && return 1
+  done
+  return 0
+}

--- a/tests/integration/global_inherit.bats
+++ b/tests/integration/global_inherit.bats
@@ -1,0 +1,114 @@
+#!/usr/bin/env bats
+
+load '../helpers.bash'
+
+setup() {
+  mosaic_setup_server
+  mosaic_use_algorithm master-stack
+}
+
+teardown() {
+  mosaic_teardown_server
+}
+
+pane_field() {
+  mosaic_t list-panes -t "${1:-t:1}" -F '#{pane_index} #{pane_left} #{pane_top} #{pane_width} #{pane_height}' |
+    awk -v idx="${2:?pane index required}" -v field="${3:?field required}" '$1 == idx { print $field }'
+}
+
+wait_pane1_left_gt_zero() {
+  mosaic_wait_until 1500 \
+    bash -c "[ \"\$(tmux -L $(mosaic_socket) list-panes -t t:1 -F '#{pane_index} #{pane_left}' | awk '\$1 == 1 { print \$2 }')\" -gt 0 ]"
+}
+
+wait_main_pane_width_eq() {
+  local expected="$1"
+  mosaic_wait_until 1500 \
+    bash -c "[ \"\$(tmux -L $(mosaic_socket) show-option -wqv -t t:1 main-pane-width 2>/dev/null)\" = \"$expected\" ]"
+}
+
+@test "global -gwq @mosaic-orientation is honored when window has no local override" {
+  mosaic_t set-option -gwq "@mosaic-orientation" "right"
+  for _ in 1 2 3; do mosaic_split; done
+  wait_pane1_left_gt_zero || true
+
+  pane1_left=$(pane_field t:1 1 2)
+  [ "$pane1_left" -gt 0 ]
+}
+
+@test "global -gwq @mosaic-orientation top puts the master on top" {
+  mosaic_t set-option -gwq "@mosaic-orientation" "top"
+  for _ in 1 2 3; do mosaic_split; done
+  mosaic_wait_until 1500 \
+    bash -c "[ \"\$(tmux -L $(mosaic_socket) list-panes -t t:1 -F '#{pane_index} #{pane_top}' | awk '\$1 == 2 { print \$2 }')\" -gt 0 ]" || true
+
+  pane1_top=$(pane_field t:1 1 3)
+  pane1_height=$(pane_field t:1 1 5)
+  pane2_top=$(pane_field t:1 2 3)
+  [ "$pane1_top" = "0" ]
+  [ "$pane2_top" -ge "$pane1_height" ]
+}
+
+@test "global -gwq @mosaic-nmaster is honored when window has no local override" {
+  mosaic_t set-option -gwq "@mosaic-nmaster" "2"
+  for _ in 1 2 3; do mosaic_split; done
+  mosaic_wait_until 1500 \
+    bash -c "[ \"\$(tmux -L $(mosaic_socket) list-panes -t t:1 -F '#{pane_index} #{pane_top}' | awk '\$1 == 2 { print \$2 }')\" -gt 0 ]" || true
+
+  pane1_left=$(pane_field t:1 1 2)
+  pane2_left=$(pane_field t:1 2 2)
+  pane3_left=$(pane_field t:1 3 2)
+  pane1_top=$(pane_field t:1 1 3)
+  pane2_top=$(pane_field t:1 2 3)
+  [ "$pane1_left" = "0" ]
+  [ "$pane2_left" = "0" ]
+  [ "$pane3_left" -gt 0 ]
+  [ "$pane2_top" -gt "$pane1_top" ]
+}
+
+@test "global -gwq @mosaic-mfact is honored when window has no local override" {
+  mosaic_t set-option -gwq "@mosaic-mfact" "70"
+  for _ in 1 2; do mosaic_split; done
+  wait_main_pane_width_eq "70%" || true
+
+  pane1_w=$(pane_field t:1 1 4)
+  total_w=$(mosaic_t display-message -p -t t:1 '#{window_width}')
+  expected_low=$((total_w * 65 / 100))
+  expected_high=$((total_w * 75 / 100))
+  [ "$pane1_w" -ge "$expected_low" ]
+  [ "$pane1_w" -le "$expected_high" ]
+}
+
+@test "window-local override beats -gwq global default" {
+  mosaic_t set-option -gwq "@mosaic-orientation" "right"
+  mosaic_t set-option -wq -t t:1 "@mosaic-orientation" "left"
+  for _ in 1 2 3; do mosaic_split; done
+
+  pane1_left=$(pane_field t:1 1 2)
+  [ "$pane1_left" = "0" ]
+}
+
+@test "removing window-local override falls back to -gwq global" {
+  mosaic_t set-option -gwq "@mosaic-orientation" "right"
+  mosaic_t set-option -wq -t t:1 "@mosaic-orientation" "left"
+  for _ in 1 2 3; do mosaic_split; done
+
+  pane1_left=$(pane_field t:1 1 2)
+  [ "$pane1_left" = "0" ]
+
+  mosaic_t set-option -wqu -t t:1 "@mosaic-orientation"
+  wait_pane1_left_gt_zero || true
+
+  pane1_left=$(pane_field t:1 1 2)
+  [ "$pane1_left" -gt 0 ]
+}
+
+@test "fingerprint reflects -gwq global when window has no local override" {
+  mosaic_t set-option -gwq "@mosaic-nmaster" "2"
+  mosaic_split
+  mosaic_wait_until 1500 \
+    bash -c "[[ \"\$(tmux -L $(mosaic_socket) show-option -wqv -t t:1 @mosaic-_fingerprint)\" == *'|2|'* ]]" || true
+
+  fp=$(mosaic_t show-option -wqv -t t:1 @mosaic-_fingerprint)
+  [[ "$fp" == *"|2|"* ]]
+}


### PR DESCRIPTION
## Problem

Closes #67.

The README's Quick Start documents `set-option -gwq @mosaic-orientation right` (and equivalents for `@mosaic-nmaster` and `@mosaic-mfact`) as the way to set window defaults globally. In practice these have no effect on a window without a window-local override, because `mosaic_get_w` and the five duplicated `*_mfact_for` implementations read the option via `show-option -wqv` without `-A`. Without `-A`, tmux only returns the window-local raw value and never inherits from the `-gw` window-option global default, so the resolved value always falls back to the helper's hardcoded default (`left`, `1`, `50`). Setting `-gwq @mosaic-orientation right` produced a left master.

## Solution

Switch the inheritance-aware reads to `show-option -wqvA`. `mosaic_get_w_raw` and `mosaic_local_algorithm` deliberately keep `-wqv` so they still distinguish "explicit window-local value" from "inherits global" — the off/unset/local-override logic in `mosaic_toggle_window` and `_on-set-option` depends on that distinction.

While in there, consolidate five copies of the same function (`algo_mfact_for` in each of master-stack / bottom-stack / centered-master / three-column, plus `mosaic_fibonacci_mfact_for` in `helpers.sh`) into a single `mosaic_mfact_for` in `helpers.sh`. The Fibonacci variant prefix was meaningless — the implementations were textually identical and no per-algo logic justified separate copies. The four `algo_mfact_for` definitions are removed; their callers now go directly to `mosaic_mfact_for`. Net diff is +148 / -66 lines, dominated by the new test file.

## Tests

`tests/integration/global_inherit.bats` covers seven regression cases:

- `-gwq @mosaic-orientation right` produces a right master on a window with no local override
- `-gwq @mosaic-orientation top` produces a top master
- `-gwq @mosaic-nmaster 2` keeps the first two panes in the master column
- `-gwq @mosaic-mfact 70` produces a master at ~70% of window width (with a tolerance band)
- A window-local `-wq` override beats `-gwq`
- Removing the window-local override (`-wqu`) falls back to the `-gwq` default
- The fingerprint cache (#65) reflects the inherited value

A small generic `mosaic_wait_until` helper was added to `tests/helpers.bash` because these tests need to poll on layout effects after the `after-set-option` hook (whose handler runs in the background via `run-shell -b`).

## Out of scope

`#72` tracks pre-existing flakiness in the broader test suite (`sleep 0.X` after async hooks). I did not convert existing tests to the new polling helper in this PR; that's a focused cleanup deserving its own change.