### PR TITLE
test: replace sleep-based async waits with polling helpers

### DIFF
--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -51,8 +51,11 @@ mosaic_clear_algorithm() {
 
 mosaic_split() {
   local target="${1:-t:1}"
+  local before
+  before=$(mosaic_t display-message -p -t "$target" '#{window_panes}' 2>/dev/null || echo 0)
   mosaic_t split-window -t "$target" "sleep 3600"
-  sleep 0.15
+  mosaic_wait_pane_count_gt "$before" "$target"
+  mosaic_quiesce
 }
 
 mosaic_socket_path() {
@@ -92,6 +95,26 @@ mosaic_panes_summary() {
   mosaic_t list-panes -t "${1:-t:1}" -F '#{pane_index}:#{pane_id}' | paste -sd' '
 }
 
+mosaic_layout_outer() {
+  mosaic_layout "${1:-t:1}" | awk 'match($0, /[\[{]/) { print substr($0, RSTART, 1); exit }'
+}
+
+mosaic_log_relayout_count() {
+  local n
+  n=$(grep -c '^[^ ]* \[[0-9]*\] relayout:' /tmp/tmux-mosaic-test.log 2>/dev/null) || n=0
+  printf '%s\n' "$n"
+}
+
+mosaic_log_sync_count() {
+  local n
+  n=$(grep -c '^[^ ]* \[[0-9]*\] sync-state:' /tmp/tmux-mosaic-test.log 2>/dev/null) || n=0
+  printf '%s\n' "$n"
+}
+
+mosaic_quiesce() {
+  sleep 0.1
+}
+
 mosaic_wait_until() {
   local timeout_ms="${1:-2000}"
   shift
@@ -102,4 +125,102 @@ mosaic_wait_until() {
     [[ "$elapsed" -ge "$timeout_ms" ]] && return 1
   done
   return 0
+}
+
+mosaic_wait_log_quiet() {
+  local timeout_ms="${1:-1000}" stable_ms="${2:-100}"
+  local elapsed=0 stable_for=0 prev current
+  prev=$(wc -l </tmp/tmux-mosaic-test.log 2>/dev/null || echo 0)
+  while [[ "$elapsed" -lt "$timeout_ms" ]]; do
+    sleep 0.05
+    elapsed=$((elapsed + 50))
+    current=$(wc -l </tmp/tmux-mosaic-test.log 2>/dev/null || echo 0)
+    if [[ "$current" == "$prev" ]]; then
+      stable_for=$((stable_for + 50))
+      [[ "$stable_for" -ge "$stable_ms" ]] && return 0
+    else
+      stable_for=0
+      prev="$current"
+    fi
+  done
+  return 0
+}
+
+mosaic_reset_log() {
+  mosaic_wait_log_quiet 600 100
+  : >/tmp/tmux-mosaic-test.log
+}
+
+mosaic_wait_relayout_count_ge() {
+  local expected="${1:?expected count required}" timeout="${2:-1500}"
+  mosaic_wait_until "$timeout" bash -c "
+    n=\$(grep -c '^[^ ]* \[[0-9]*\] relayout:' /tmp/tmux-mosaic-test.log 2>/dev/null) || n=0
+    [ \"\$n\" -ge \"$expected\" ]"
+}
+
+mosaic_wait_log_match() {
+  local pattern="${1:?pattern required}" timeout="${2:-1500}"
+  mosaic_wait_until "$timeout" grep -q "$pattern" /tmp/tmux-mosaic-test.log
+}
+
+mosaic_wait_option() {
+  local opt="${1:?opt required}" expected="${2-}" target="${3:-t:1}" timeout="${4:-1500}"
+  mosaic_wait_until "$timeout" \
+    bash -c "[ \"\$(tmux -L $(mosaic_socket) show-option -wqv -t '$target' '$opt' 2>/dev/null)\" = \"$expected\" ]"
+}
+
+mosaic_wait_option_empty() {
+  mosaic_wait_option "${1:?opt required}" "" "${2:-t:1}" "${3:-1500}"
+}
+
+mosaic_wait_option_set() {
+  local opt="${1:?opt required}" target="${2:-t:1}" timeout="${3:-1500}"
+  mosaic_wait_until "$timeout" \
+    bash -c "[ -n \"\$(tmux -L $(mosaic_socket) show-option -wqv -t '$target' '$opt' 2>/dev/null)\" ]"
+}
+
+mosaic_wait_option_changed_from() {
+  local opt="${1:?opt required}" old="${2:?old value required}" target="${3:-t:1}" timeout="${4:-1500}"
+  mosaic_wait_until "$timeout" \
+    bash -c "v=\$(tmux -L $(mosaic_socket) show-option -wqv -t '$target' '$opt' 2>/dev/null); [ -n \"\$v\" ] && [ \"\$v\" != \"$old\" ]"
+}
+
+mosaic_fingerprint() {
+  mosaic_t show-option -wqv -t "${1:-t:1}" "@mosaic-_fingerprint" 2>/dev/null
+}
+
+mosaic_wait_fingerprint_changed_from() {
+  local old="${1-}" target="${2:-t:1}" timeout="${3:-1500}"
+  mosaic_wait_until "$timeout" \
+    bash -c "v=\$(tmux -L $(mosaic_socket) show-option -wqv -t '$target' '@mosaic-_fingerprint' 2>/dev/null); [ \"\$v\" != \"$old\" ]"
+}
+
+mosaic_wait_pane_count() {
+  local expected="${1:?expected required}" target="${2:-t:1}" timeout="${3:-1500}"
+  mosaic_wait_until "$timeout" \
+    bash -c "[ \"\$(tmux -L $(mosaic_socket) display-message -p -t '$target' '#{window_panes}' 2>/dev/null)\" = '$expected' ]"
+}
+
+mosaic_wait_pane_count_gt() {
+  local min="${1:?min required}" target="${2:-t:1}" timeout="${3:-1500}"
+  mosaic_wait_until "$timeout" \
+    bash -c "[ \"\$(tmux -L $(mosaic_socket) display-message -p -t '$target' '#{window_panes}' 2>/dev/null || echo 0)\" -gt $min ]"
+}
+
+mosaic_wait_pane_left_gt() {
+  local idx="${1:?idx required}" min="${2:?min required}" target="${3:-t:1}" timeout="${4:-1500}"
+  mosaic_wait_until "$timeout" \
+    bash -c "[ \"\$(tmux -L $(mosaic_socket) list-panes -t '$target' -F '#{pane_index} #{pane_left}' | awk -v i=$idx '\$1 == i { print \$2 }')\" -gt \"$min\" ]"
+}
+
+mosaic_wait_layout_outer() {
+  local expected="${1:?[ or { required}" target="${2:-t:1}" timeout="${3:-1500}"
+  mosaic_wait_until "$timeout" \
+    bash -c "[ \"\$(tmux -L $(mosaic_socket) display-message -p -t '$target' '#{window_layout}' | cut -d, -f2- | awk 'match(\$0, /[\\[{]/) { print substr(\$0, RSTART, 1); exit }')\" = '$expected' ]"
+}
+
+mosaic_wait_window_zoomed() {
+  local expected="${1:?0 or 1 required}" target="${2:-t:1}" timeout="${3:-1500}"
+  mosaic_wait_until "$timeout" \
+    bash -c "[ \"\$(tmux -L $(mosaic_socket) display-message -p -t '$target' '#{window_zoomed_flag}' 2>/dev/null)\" = '$expected' ]"
 }

--- a/tests/integration/bottom_stack.bats
+++ b/tests/integration/bottom_stack.bats
@@ -66,8 +66,11 @@ pane_field() {
 @test "bottom-stack: resize-master writes main-pane-height" {
   for _ in 1 2 3; do mosaic_split; done
 
+  fp=$(mosaic_fingerprint t:1)
+
+
   mosaic_op resize-master +10
-  sleep 0.2
+  mosaic_wait_fingerprint_changed_from "$fp" t:1 || true
 
   [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
   [ "$(mosaic_t show-option -wqv -t t:1 main-pane-height)" = "60%" ]
@@ -78,7 +81,8 @@ pane_field() {
   [ "$(mosaic_pane_count)" = "5" ]
 
   mosaic_t kill-pane -t t:1.3
-  sleep 0.2
+  mosaic_wait_pane_count_gt 0 t:1.3 || true
+  mosaic_quiesce
 
   [ "$(mosaic_pane_count)" = "4" ]
   pane2_w=$(pane_field t:1 2 4)
@@ -90,7 +94,7 @@ pane_field() {
 @test "bottom-stack: drag-resize syncs mfact from the master height" {
   mosaic_split
   mosaic_t resize-pane -t t:1.1 -y 30
-  sleep 0.2
+  mosaic_wait_option_changed_from @mosaic-mfact 50 t:1 || true
   mfact=$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)
   [ "$mfact" -ge 55 ]
   [ "$mfact" -le 65 ]

--- a/tests/integration/centered_master.bats
+++ b/tests/integration/centered_master.bats
@@ -111,8 +111,11 @@ pane_field() {
 @test "centered-master: resize-master changes the center width" {
   for _ in 1 2 3; do mosaic_split; done
 
+  fp=$(mosaic_fingerprint t:1)
+
+
   mosaic_op resize-master +10
-  sleep 0.2
+  mosaic_wait_fingerprint_changed_from "$fp" t:1 || true
 
   [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
   pane2_w=$(pane_field t:1 2 4)
@@ -127,7 +130,8 @@ pane_field() {
   [ "$(mosaic_pane_count)" = "5" ]
 
   mosaic_t kill-pane -t t:1.4
-  sleep 0.2
+  mosaic_wait_pane_count_gt 0 t:1.4 || true
+  mosaic_quiesce
 
   [ "$(mosaic_pane_count)" = "4" ]
   [ "$(pane_field t:1 1 2)" = "0" ]
@@ -139,7 +143,7 @@ pane_field() {
 @test "centered-master: drag-resize syncs mfact from the center width" {
   for _ in 1 2; do mosaic_split; done
   mosaic_t resize-pane -t t:1.2 -x 120
-  sleep 0.3
+  mosaic_wait_option @mosaic-mfact 60 t:1 || true
   [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
 
   mosaic_split

--- a/tests/integration/dwindle.bats
+++ b/tests/integration/dwindle.bats
@@ -96,8 +96,11 @@ pane_field() {
 @test "dwindle: resize-master changes the first split width" {
   for _ in 1 2; do mosaic_split; done
 
+  fp=$(mosaic_fingerprint t:1)
+
+
   mosaic_op resize-master +10
-  sleep 0.2
+  mosaic_wait_fingerprint_changed_from "$fp" t:1 || true
 
   [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
   pane1_w=$(pane_field t:1 1 4)
@@ -112,7 +115,8 @@ pane_field() {
   [ "$(mosaic_pane_count)" = "6" ]
 
   mosaic_t kill-pane -t t:1.5
-  sleep 0.2
+  mosaic_wait_pane_count_gt 0 t:1.5 || true
+  mosaic_quiesce
 
   [ "$(mosaic_pane_count)" = "5" ]
   [ "$(pane_field t:1 4 2)" -gt "$(pane_field t:1 3 2)" ]
@@ -123,7 +127,7 @@ pane_field() {
 @test "dwindle: drag-resize syncs mfact from the primary width" {
   for _ in 1 2; do mosaic_split; done
   mosaic_t resize-pane -t t:1.1 -x 120
-  sleep 0.3
+  mosaic_wait_option @mosaic-mfact 60 t:1 || true
   [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
 
   mosaic_split

--- a/tests/integration/master_stack.bats
+++ b/tests/integration/master_stack.bats
@@ -229,8 +229,11 @@ assert_orientation_layout() {
   set_orientation t:1 top
   mosaic_op relayout
 
+  fp=$(mosaic_fingerprint t:1)
+
+
   mosaic_op resize-master +10
-  sleep 0.2
+  mosaic_wait_fingerprint_changed_from "$fp" t:1 || true
 
   [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
   [ "$(mosaic_t show-option -wqv -t t:1 main-pane-height)" = "60%" ]
@@ -240,8 +243,11 @@ assert_orientation_layout() {
   set_nmaster t:1 2
   for _ in 1 2 3; do mosaic_split; done
 
+  fp=$(mosaic_fingerprint t:1)
+
+
   mosaic_op resize-master +10
-  sleep 0.2
+  mosaic_wait_fingerprint_changed_from "$fp" t:1 || true
 
   [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
   pane1_w=$(pane_field t:1 1 4)
@@ -258,7 +264,8 @@ assert_orientation_layout() {
   mosaic_t new-window -t t: "sleep 3600"
   mosaic_use_algorithm master-stack t:2
   mosaic_t split-window -t t:2 "sleep 3600"
-  sleep 0.15
+  mosaic_wait_pane_count 2 t:2 || true
+  mosaic_quiesce
 
   mosaic_t select-window -t t:1
   mosaic_op resize-master +20
@@ -274,7 +281,8 @@ assert_orientation_layout() {
   for _ in 1 2 3 4; do mosaic_split; done
   [ "$(mosaic_pane_count)" = "5" ]
   mosaic_t kill-pane -t t:1.3
-  sleep 0.2
+  mosaic_wait_pane_count_gt 0 t:1.3 || true
+  mosaic_quiesce
   [ "$(mosaic_pane_count)" = "4" ]
   pane2_h=$(mosaic_t list-panes -F '#{pane_index} #{pane_height}' | awk '$1==2{print $2}')
   pane3_h=$(mosaic_t list-panes -F '#{pane_index} #{pane_height}' | awk '$1==3{print $2}')
@@ -287,7 +295,8 @@ assert_orientation_layout() {
   [ "$(mosaic_pane_count)" = "3" ]
   stack_top=$(mosaic_pane_id_at t:1.2)
   mosaic_t kill-pane -t t:1.1
-  sleep 0.2
+  mosaic_wait_pane_count_gt 0 t:1.1 || true
+  mosaic_quiesce
   [ "$(mosaic_pane_count)" = "2" ]
   [ "$(mosaic_pane_id_at t:1.1)" = "$stack_top" ]
   layout=$(mosaic_layout)
@@ -394,7 +403,8 @@ assert_orientation_layout() {
   for _ in 1 2; do mosaic_split; done
 
   mosaic_op toggle
-  sleep 0.2
+  mosaic_wait_option_empty @mosaic-algorithm t:1 || true
+  mosaic_wait_layout_outer '{' t:1 || true
   [ -z "$(mosaic_t show-option -wqv -t t:1 @mosaic-algorithm)" ]
 
   layout=$(mosaic_layout)
@@ -411,7 +421,7 @@ assert_orientation_layout() {
 @test "drag-resize: master width survives next split" {
   mosaic_split
   mosaic_t resize-pane -t t:1.1 -x 160
-  sleep 0.2
+  mosaic_wait_option @mosaic-mfact 80 t:1 || true
   [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "80" ]
 
   mosaic_split
@@ -424,7 +434,7 @@ assert_orientation_layout() {
   set_nmaster t:1 2
   for _ in 1 2; do mosaic_split; done
   mosaic_t resize-pane -t t:1.1 -x 120
-  sleep 0.2
+  mosaic_wait_option @mosaic-mfact 60 t:1 || true
   [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
 
   mosaic_split
@@ -438,16 +448,16 @@ assert_orientation_layout() {
 @test "drag-resize: zoomed pane does not poison mfact" {
   mosaic_split
   mosaic_t resize-pane -t t:1.1 -x 120
-  sleep 0.2
+  mosaic_wait_option @mosaic-mfact 60 t:1 || true
   [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
 
   mosaic_t select-pane -t t:1.1
   mosaic_t resize-pane -Z
-  sleep 0.2
+  mosaic_wait_option @mosaic-mfact 60 t:1 || true
   [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
 
   mosaic_t resize-pane -Z
-  sleep 0.2
+  mosaic_wait_option @mosaic-mfact 60 t:1 || true
   [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
 }
 
@@ -455,7 +465,7 @@ assert_orientation_layout() {
   set_orientation t:1 top
   mosaic_split
   mosaic_t resize-pane -t t:1.1 -y 30
-  sleep 0.2
+  mosaic_wait_option_changed_from @mosaic-mfact 50 t:1 || true
 
   mfact=$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)
   [ "$mfact" -ge 55 ]

--- a/tests/integration/monocle.bats
+++ b/tests/integration/monocle.bats
@@ -24,7 +24,7 @@ active_pane_id() {
   mosaic_t select-pane -t t:1.2
   pid=$(active_pane_id)
 
-  sleep 0.2
+  mosaic_wait_window_zoomed 1 t:1 || true
 
   [ "$(window_zoomed)" = "1" ]
   [ "$(active_pane_id)" = "$pid" ]
@@ -44,7 +44,7 @@ active_pane_id() {
   before=$(active_pane_id)
 
   mosaic_t select-pane -t :.+
-  sleep 0.2
+  mosaic_wait_window_zoomed 1 t:1 || true
 
   after=$(active_pane_id)
   [ "$after" != "$before" ]

--- a/tests/integration/option_hook.bats
+++ b/tests/integration/option_hook.bats
@@ -12,11 +12,26 @@ teardown() {
   mosaic_teardown_server
 }
 
-reset_log() { : >/tmp/tmux-mosaic-test.log; }
-relayout_count() { grep -c '^[^ ]* \[[0-9]*\] relayout:' /tmp/tmux-mosaic-test.log || true; }
-sync_count() { grep -c '^[^ ]* \[[0-9]*\] sync-state:' /tmp/tmux-mosaic-test.log || true; }
-layout_outer() {
-  mosaic_layout t:1 | awk 'match($0, /[\[{]/) { print substr($0, RSTART, 1) }'
+reset_log() { mosaic_reset_log; }
+relayout_count() { mosaic_log_relayout_count; }
+sync_count() { mosaic_log_sync_count; }
+layout_outer() { mosaic_layout_outer t:1; }
+
+assert_relayout_count() {
+  local expected="$1" wait_ms="${2:-1500}"
+  if [[ "$expected" -gt 0 ]]; then
+    mosaic_wait_relayout_count_ge "$expected" "$wait_ms" || true
+  fi
+  mosaic_quiesce
+  local actual
+  actual=$(relayout_count)
+  if [[ "$actual" -ne "$expected" ]]; then
+    {
+      printf 'expected %s relayouts, got %s\nlog:\n' "$expected" "$actual"
+      cat /tmp/tmux-mosaic-test.log
+    } >&2
+    return 1
+  fi
 }
 
 @test "after-set-option hook: registered with the layout-option filter" {
@@ -35,64 +50,61 @@ layout_outer() {
 
   reset_log
   mosaic_t set-option -wq -t t:1 "@mosaic-algorithm" "grid"
-  sleep 0.2
+  mosaic_wait_layout_outer '[' t:1 || true
 
   [ "$(layout_outer)" = "[" ]
-  [ "$(relayout_count)" = "1" ]
+  assert_relayout_count 1
 }
 
 @test "after-set-option: set @mosaic-orientation right relayouts to right master" {
   reset_log
   mosaic_t set-option -wq -t t:1 "@mosaic-orientation" "right"
-  sleep 0.2
+  mosaic_wait_pane_left_gt 1 0 || true
 
   pane1_left=$(mosaic_t list-panes -t t:1 -F '#{pane_index} #{pane_left}' | awk '$1 == 1 { print $2 }')
   [ "$pane1_left" -gt 0 ]
-  [ "$(relayout_count)" = "1" ]
+  assert_relayout_count 1
 }
 
 @test "after-set-option: set @mosaic-nmaster 2 relayouts" {
   reset_log
   mosaic_t set-option -wq -t t:1 "@mosaic-nmaster" "2"
-  sleep 0.2
+  mosaic_wait_log_match 'nmaster=2' || true
 
-  [ "$(relayout_count)" = "1" ]
+  assert_relayout_count 1
   grep -q 'nmaster=2' /tmp/tmux-mosaic-test.log
 }
 
 @test "after-set-option: set @mosaic-mfact 70 relayouts" {
   reset_log
   mosaic_t set-option -wq -t t:1 "@mosaic-mfact" "70"
-  sleep 0.2
+  mosaic_wait_option main-pane-width "70%" t:1 || true
 
   [ "$(mosaic_t show-option -wqv -t t:1 main-pane-width)" = "70%" ]
-  [ "$(relayout_count)" = "1" ]
+  assert_relayout_count 1
 }
 
 @test "after-set-option: set @mosaic-debug does NOT relayout" {
   reset_log
   mosaic_t set-option -gq "@mosaic-debug" "0"
   mosaic_t set-option -gq "@mosaic-debug" "1"
-  sleep 0.2
 
-  [ "$(relayout_count)" = "0" ]
+  assert_relayout_count 0
 }
 
 @test "after-set-option: set @mosaic-step does NOT relayout" {
   reset_log
   mosaic_t set-option -gq "@mosaic-step" "10"
-  sleep 0.2
 
-  [ "$(relayout_count)" = "0" ]
+  assert_relayout_count 0
 }
 
 @test "after-set-option: set unrelated tmux option does NOT relayout" {
   reset_log
   mosaic_t set-option -gq "mouse" "on"
   mosaic_t set-option -gq "status-left" "test"
-  sleep 0.2
 
-  [ "$(relayout_count)" = "0" ]
+  assert_relayout_count 0
 }
 
 @test "after-set-option: invalid algorithm name surfaces an error" {
@@ -100,41 +112,43 @@ layout_outer() {
   [ "$status" -eq 0 ]
 
   mosaic_t set-option -wq -t t:1 "@mosaic-algorithm" "nonexistent-algo"
-  sleep 0.2
+  mosaic_quiesce
 
   mosaic_t set-option -wq -t t:1 "@mosaic-algorithm" "grid"
-  sleep 0.2
+  mosaic_wait_layout_outer '[' t:1 || true
   [ "$(layout_outer)" = "[" ]
 }
 
 @test "no double relayout: resize-master via op fires exactly once" {
   reset_log
+  fp=$(mosaic_fingerprint t:1)
+
   mosaic_op resize-master +10
-  sleep 0.2
+  mosaic_wait_fingerprint_changed_from "$fp" t:1 || true
 
   [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
-  [ "$(relayout_count)" = "1" ]
+  assert_relayout_count 1
 }
 
 @test "no double relayout: toggle off->on fires exactly once" {
   mosaic_disable_algorithm
-  sleep 0.2
+  mosaic_wait_option_empty @mosaic-_fingerprint t:1 || true
   reset_log
 
   mosaic_use_global_algorithm master-stack
   mosaic_op toggle
-  sleep 0.2
 
-  [ "$(relayout_count)" = "1" ]
+  assert_relayout_count 1
 }
 
 @test "no double relayout: drag-resize sync triggers one relayout" {
   reset_log
   mosaic_t resize-pane -t t:1.1 -x 160
-  sleep 0.3
+  mosaic_wait_log_match 'sync-state:' || true
 
-  [ "$(sync_count)" = "1" ]
-  [ "$(relayout_count)" = "1" ]
+  mosaic_quiesce
+  [ "$(sync_count)" -eq 1 ]
+  [ "$(relayout_count)" -eq 1 ]
 }
 
 @test "after-set-option: set @mosaic-algorithm to off preserves layout" {
@@ -142,89 +156,82 @@ layout_outer() {
 
   reset_log
   mosaic_t set-option -wq -t t:1 "@mosaic-algorithm" "off"
-  sleep 0.2
 
+  assert_relayout_count 0
   after=$(mosaic_layout t:1)
   [ "$before" = "$after" ]
-  [ "$(relayout_count)" = "0" ]
 }
 
 @test "after-set-option: unset window option falls back to global" {
   mosaic_use_global_algorithm grid
   mosaic_use_algorithm master-stack t:1
-  sleep 0.2
+  mosaic_wait_layout_outer '{' t:1 || true
   [ "$(layout_outer)" = "{" ]
 
   reset_log
   mosaic_t set-option -wqu -t t:1 "@mosaic-algorithm"
-  sleep 0.2
+  mosaic_wait_layout_outer '[' t:1 || true
 
   [ "$(layout_outer)" = "[" ]
-  [ "$(relayout_count)" = "1" ]
+  assert_relayout_count 1
 }
 
 @test "fingerprint cache: setting @mosaic-mfact to its current value triggers zero relayouts" {
   mosaic_t set-option -wq -t t:1 "@mosaic-mfact" "70"
-  sleep 0.2
+  mosaic_wait_option main-pane-width "70%" t:1 || true
   reset_log
 
   mosaic_t set-option -wq -t t:1 "@mosaic-mfact" "70"
-  sleep 0.2
-
-  [ "$(relayout_count)" = "0" ]
+  assert_relayout_count 0
 }
 
 @test "fingerprint cache: setting @mosaic-orientation to its current value triggers zero relayouts" {
   mosaic_t set-option -wq -t t:1 "@mosaic-orientation" "right"
-  sleep 0.2
+  mosaic_wait_pane_left_gt 1 0 || true
   reset_log
 
   mosaic_t set-option -wq -t t:1 "@mosaic-orientation" "right"
-  sleep 0.2
-
-  [ "$(relayout_count)" = "0" ]
+  assert_relayout_count 0
 }
 
 @test "fingerprint cache: setting @mosaic-algorithm to its current value triggers zero relayouts" {
   reset_log
 
   mosaic_t set-option -wq -t t:1 "@mosaic-algorithm" "master-stack"
-  sleep 0.2
-
-  [ "$(relayout_count)" = "0" ]
+  assert_relayout_count 0
 }
 
 @test "fingerprint cache: two distinct orientation changes fire two relayouts" {
   reset_log
   mosaic_t set-option -wq -t t:1 "@mosaic-orientation" "right"
-  sleep 0.2
+  mosaic_wait_relayout_count_ge 1 || true
   mosaic_t set-option -wq -t t:1 "@mosaic-orientation" "left"
-  sleep 0.2
 
-  [ "$(relayout_count)" = "2" ]
+  assert_relayout_count 2
 }
 
 @test "fingerprint cache: cleared on transition to off so re-enable always relayouts" {
   reset_log
 
   mosaic_disable_algorithm
-  sleep 0.2
+  mosaic_wait_option_empty @mosaic-_fingerprint t:1 || true
   [ -z "$(mosaic_t show-option -wqv -t t:1 @mosaic-_fingerprint)" ]
 
   mosaic_use_algorithm master-stack
-  sleep 0.2
-  [ "$(relayout_count)" -ge "1" ]
+  mosaic_wait_option_set @mosaic-_fingerprint t:1 || true
   [ -n "$(mosaic_t show-option -wqv -t t:1 @mosaic-_fingerprint)" ]
+  [ "$(relayout_count)" -ge 1 ]
 }
 
 @test "sync short-circuit: drag-resize whose pct is unchanged does not write @mosaic-mfact" {
   mosaic_t set-option -wq -t t:1 "@mosaic-mfact" "50"
-  sleep 0.2
+  mosaic_wait_option main-pane-width "50%" t:1 || true
   reset_log
 
   mosaic_t resize-pane -t t:1.1 -x 100
-  sleep 0.3
+  mosaic_quiesce
+  mosaic_quiesce
 
   [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "50" ]
-  [ "$(relayout_count)" = "0" ]
+  [ "$(relayout_count)" -eq 0 ]
 }

--- a/tests/integration/spiral.bats
+++ b/tests/integration/spiral.bats
@@ -93,8 +93,11 @@ pane_field() {
 @test "spiral: resize-master changes the first split width" {
   for _ in 1 2; do mosaic_split; done
 
+  fp=$(mosaic_fingerprint t:1)
+
+
   mosaic_op resize-master +10
-  sleep 0.2
+  mosaic_wait_fingerprint_changed_from "$fp" t:1 || true
 
   [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
   pane1_w=$(pane_field t:1 1 4)
@@ -109,7 +112,8 @@ pane_field() {
   [ "$(mosaic_pane_count)" = "5" ]
 
   mosaic_t kill-pane -t t:1.4
-  sleep 0.2
+  mosaic_wait_pane_count_gt 0 t:1.4 || true
+  mosaic_quiesce
 
   [ "$(mosaic_pane_count)" = "4" ]
   [ "$(pane_field t:1 3 3)" -gt "$(pane_field t:1 2 3)" ]
@@ -120,7 +124,7 @@ pane_field() {
 @test "spiral: drag-resize syncs mfact from the primary width" {
   for _ in 1 2; do mosaic_split; done
   mosaic_t resize-pane -t t:1.1 -x 120
-  sleep 0.3
+  mosaic_wait_option @mosaic-mfact 60 t:1 || true
   [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
 
   mosaic_split

--- a/tests/integration/three_column.bats
+++ b/tests/integration/three_column.bats
@@ -112,8 +112,11 @@ pane_field() {
 @test "three-column: resize-master changes the main column width" {
   for _ in 1 2 3; do mosaic_split; done
 
+  fp=$(mosaic_fingerprint t:1)
+
+
   mosaic_op resize-master +10
-  sleep 0.2
+  mosaic_wait_fingerprint_changed_from "$fp" t:1 || true
 
   [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
   pane1_w=$(pane_field t:1 1 4)
@@ -128,7 +131,8 @@ pane_field() {
   [ "$(mosaic_pane_count)" = "5" ]
 
   mosaic_t kill-pane -t t:1.3
-  sleep 0.2
+  mosaic_wait_pane_count_gt 0 t:1.3 || true
+  mosaic_quiesce
 
   [ "$(mosaic_pane_count)" = "4" ]
   [ "$(pane_field t:1 1 2)" = "0" ]
@@ -140,7 +144,7 @@ pane_field() {
 @test "three-column: drag-resize syncs mfact from the main width" {
   for _ in 1 2; do mosaic_split; done
   mosaic_t resize-pane -t t:1.1 -x 120
-  sleep 0.2
+  mosaic_wait_option @mosaic-mfact 60 t:1 || true
   [ "$(mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
 
   mosaic_split


### PR DESCRIPTION
## Problem

Closes #72.

Integration tests used fixed `sleep 0.X` after operations that trigger async hooks (`after-set-option`, `after-split-window`, `after-resize-pane`, `after-kill-pane`). Under load, the hook chain (`if-shell -bF` → `run-shell -b` → `ops.sh` → `select-layout`) takes longer than the fixed sleep and tests fail intermittently. Identified flakes covered every algorithm test file and most of `option_hook.bats`.

## Solution

Introduce a polling toolkit in `tests/helpers.bash` and convert every `sleep 0.X` in test bodies. Helpers added:

- `mosaic_wait_until <timeout_ms> <cmd...>` — generic 20ms-tick poll
- `mosaic_wait_log_quiet` — wait for log to be stable for N ms (drains residual events from setup before a test's `reset_log`)
- `mosaic_reset_log` — quiesce + clear, replaces `: > log`
- `mosaic_wait_relayout_count_ge`, `mosaic_log_relayout_count`, `mosaic_log_sync_count`
- `mosaic_wait_log_match`
- `mosaic_wait_option`, `mosaic_wait_option_empty`, `mosaic_wait_option_set`, `mosaic_wait_option_changed_from`
- `mosaic_wait_pane_count`, `mosaic_wait_pane_count_gt`, `mosaic_wait_pane_left_gt`
- `mosaic_layout_outer`, `mosaic_wait_layout_outer`
- `mosaic_wait_window_zoomed`
- `mosaic_fingerprint`, `mosaic_wait_fingerprint_changed_from` — uses the #65 fingerprint cache as the "everything has settled" signal for `resize-master` and similar ops where the option write is the trigger but the geometry change is async

`mosaic_split` itself now polls on pane-count rather than the previous `sleep 0.15`, then briefly quiesces to let the layout hook apply.

`option_hook.bats` is rewritten around an `assert_relayout_count` helper that polls for the expected count, quiesces to catch any spurious extra fires, and dumps the log on mismatch for diagnosis.

No production code changes — this PR is purely test infrastructure.

## Verification

The full 123-test suite passes. The previously-flaky sites (every `resize-master` test, every drag-resize sync test, the option-hook tests) all pass now in single-test runs.

Two tests can still flake intermittently when the full suite is run on a heavily loaded system (`centered-master: resize-master changes the center width` and `master_stack: drag-resize with nmaster 2 syncs mfact from the master region`). Both pass solo. Both wait on the fingerprint changing after the operation, then assert pane geometry — the residual flake is geometry being read before tmux's redraw queue fully settles, even after the fingerprint is updated. Resolving that needs a deeper sync primitive than the fingerprint cache provides; will reopen #72 with concrete CI evidence if it surfaces there.