### PR TITLE
feat(model): bootstrap pane ownership state

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -99,6 +99,126 @@ _mosaic_window_zoomed() {
   tmux display-message -p -t "$(_mosaic_resolve_window "${1:-}")" '#{window_zoomed_flag}'
 }
 
+_mosaic_window_generation_get() {
+  _mosaic_get_w_raw "@mosaic-_generation" "${1:-}"
+}
+
+_mosaic_window_generation_set() {
+  local win="$1" generation="$2"
+  tmux set-option -wq -t "$win" "@mosaic-_generation" "$generation"
+}
+
+_mosaic_window_generation_unset() {
+  tmux set-option -wqu -t "$1" "@mosaic-_generation" 2>/dev/null
+}
+
+_mosaic_window_state_get() {
+  _mosaic_get_w_raw "@mosaic-_state" "${1:-}"
+}
+
+_mosaic_window_state_set() {
+  local win="$1" state="$2"
+  tmux set-option -wq -t "$win" "@mosaic-_state" "$state"
+}
+
+_mosaic_window_state_unset() {
+  tmux set-option -wqu -t "$1" "@mosaic-_state" 2>/dev/null
+}
+
+_mosaic_pane_owner_generation_get() {
+  local pane="$1" val
+  val=$(tmux show-option -pqv -t "$pane" "@mosaic-_owner-generation" 2>/dev/null)
+  printf '%s\n' "$val"
+}
+
+_mosaic_pane_owner_generation_set() {
+  local pane="$1" generation="$2"
+  tmux set-option -pq -t "$pane" "@mosaic-_owner-generation" "$generation"
+}
+
+_mosaic_pane_owner_generation_unset() {
+  tmux set-option -pqu -t "$1" "@mosaic-_owner-generation" 2>/dev/null
+}
+
+_mosaic_window_panes() {
+  tmux list-panes -t "$(_mosaic_resolve_window "${1:-}")" -F '#{pane_id}' 2>/dev/null || true
+}
+
+_mosaic_window_generation_new() {
+  local win="$1"
+  printf '%s\n' "${win}:$(date +%s%N):$$:$RANDOM"
+}
+
+_mosaic_window_generation_ensure() {
+  local win generation
+  win=$(_mosaic_resolve_window "${1:-}")
+  generation=$(_mosaic_window_generation_get "$win")
+  if [[ -z "$generation" ]]; then
+    generation=$(_mosaic_window_generation_new "$win")
+    _mosaic_window_generation_set "$win" "$generation"
+  fi
+  printf '%s\n' "$generation"
+}
+
+_mosaic_pane_is_owned_by_window() {
+  local pane="$1" win generation owner_generation
+  win=$(_mosaic_resolve_window "${2:-}")
+  generation=$(_mosaic_window_generation_get "$win")
+  [[ -n "$generation" ]] || return 1
+  owner_generation=$(_mosaic_pane_owner_generation_get "$pane")
+  [[ -n "$owner_generation" && "$owner_generation" == "$generation" ]]
+}
+
+_mosaic_window_owned_panes() {
+  local win pane
+  win=$(_mosaic_resolve_window "${1:-}")
+  while IFS= read -r pane; do
+    [[ -n "$pane" ]] || continue
+    _mosaic_pane_is_owned_by_window "$pane" "$win" && printf '%s\n' "$pane"
+  done < <(_mosaic_window_panes "$win")
+}
+
+_mosaic_window_foreign_panes() {
+  local win pane
+  win=$(_mosaic_resolve_window "${1:-}")
+  while IFS= read -r pane; do
+    [[ -n "$pane" ]] || continue
+    _mosaic_pane_is_owned_by_window "$pane" "$win" || printf '%s\n' "$pane"
+  done < <(_mosaic_window_panes "$win")
+}
+
+_mosaic_window_adopt_current_panes() {
+  local win generation pane
+  win=$(_mosaic_resolve_window "${1:-}")
+  generation=$(_mosaic_window_generation_ensure "$win")
+  while IFS= read -r pane; do
+    [[ -n "$pane" ]] || continue
+    _mosaic_pane_owner_generation_set "$pane" "$generation"
+  done < <(_mosaic_window_panes "$win")
+  _mosaic_window_state_set "$win" "managed"
+}
+
+_mosaic_window_bootstrap_ownership() {
+  local win pane_count
+  win=$(_mosaic_resolve_window "${1:-}")
+  _mosaic_window_has_layout "$win" || return 0
+  [[ -z "$(_mosaic_window_generation_get "$win")" ]] || return 0
+  pane_count=$(_mosaic_window_pane_count "$win")
+  [[ "$pane_count" -ge 1 ]] || return 0
+  _mosaic_window_adopt_current_panes "$win"
+}
+
+_mosaic_window_ownership_clear() {
+  local win pane
+  win=$(_mosaic_resolve_window "${1:-}")
+  while IFS= read -r pane; do
+    [[ -n "$pane" ]] || continue
+    _mosaic_pane_owner_generation_unset "$pane"
+  done < <(_mosaic_window_panes "$win")
+  _mosaic_window_state_unset "$win"
+  _mosaic_window_generation_unset "$win"
+}
+
 _mosaic_nmaster_for() {
   local target="${1:-}" val
   val=$(_mosaic_get_w "@mosaic-nmaster" "1" "$target")

--- a/scripts/ops.sh
+++ b/scripts/ops.sh
@@ -48,6 +48,7 @@ fi
 if [[ -z "$layout" ]]; then
   case "$cmd" in
   _on-set-option)
+    _mosaic_window_ownership_clear "$target_window"
     _mosaic_fingerprint_unset "$target_window"
     _mosaic_pending_fingerprint_unset "$target_window"
     exit 0
@@ -71,6 +72,12 @@ if [[ $load_rc -ne 0 ]]; then
   esac
   exit 1
 fi
+
+case "$cmd" in
+relayout | _on-set-option | _sync-state | promote | resize-master)
+  _mosaic_window_bootstrap_ownership "$target_window"
+  ;;
+esac
 
 if [[ "$cmd" == "_on-set-option" ]]; then
   fingerprint=$(_mosaic_compute_fingerprint "$target_window" "$layout")

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -108,6 +108,18 @@ _mosaic_layout() {
   _mosaic_t display-message -p -t "${1:-t:1}" '#{window_layout}' | cut -d, -f2-
 }
 
+_mosaic_window_generation() {
+  _mosaic_t show-option -wqv -t "${1:-t:1}" "@mosaic-_generation" 2>/dev/null
+}
+
+_mosaic_window_state() {
+  _mosaic_t show-option -wqv -t "${1:-t:1}" "@mosaic-_state" 2>/dev/null
+}
+
+_mosaic_pane_owner_generation() {
+  _mosaic_t show-option -pqv -t "${1:?pane required}" "@mosaic-_owner-generation" 2>/dev/null
+}
+
 _mosaic_op() {
   local exec
   exec=$(_mosaic_t show-option -gqv "@mosaic-exec")
@@ -211,6 +223,30 @@ _mosaic_wait_option_set() {
   local opt="${1:?opt required}" target="${2:-t:1}" timeout="${3:-3000}"
   _mosaic_wait_until "$timeout" \
     bash -c "[ -n \"\$(tmux -L $(_mosaic_socket) show-option -wqv -t '$target' '$opt' 2>/dev/null)\" ]"
+}
+
+_mosaic_wait_window_generation_set() {
+  local target="${1:-t:1}" timeout="${2:-3000}"
+  _mosaic_wait_until "$timeout" \
+    bash -c "[ -n \"\$(tmux -L $(_mosaic_socket) show-option -wqv -t '$target' '@mosaic-_generation' 2>/dev/null)\" ]"
+}
+
+_mosaic_wait_window_generation_empty() {
+  local target="${1:-t:1}" timeout="${2:-3000}"
+  _mosaic_wait_until "$timeout" \
+    bash -c "[ -z \"\$(tmux -L $(_mosaic_socket) show-option -wqv -t '$target' '@mosaic-_generation' 2>/dev/null)\" ]"
+}
+
+_mosaic_wait_window_state() {
+  local expected="${1-}" target="${2:-t:1}" timeout="${3:-3000}"
+  _mosaic_wait_until "$timeout" \
+    bash -c "[ \"\$(tmux -L $(_mosaic_socket) show-option -wqv -t '$target' '@mosaic-_state' 2>/dev/null)\" = \"$expected\" ]"
+}
+
+_mosaic_wait_pane_owner_generation() {
+  local pane="${1:?pane required}" expected="${2-}" timeout="${3:-3000}"
+  _mosaic_wait_until "$timeout" \
+    bash -c "[ \"\$(tmux -L $(_mosaic_socket) show-option -pqv -t '$pane' '@mosaic-_owner-generation' 2>/dev/null)\" = \"$expected\" ]"
 }
 
 _mosaic_wait_option_changed_from() {

--- a/tests/integration/ownership.bats
+++ b/tests/integration/ownership.bats
@@ -1,0 +1,123 @@
+#!/usr/bin/env bats
+
+load '../helpers.bash'
+
+setup() {
+  _mosaic_setup_server
+}
+
+teardown() {
+  _mosaic_teardown_server
+}
+
+assert_all_panes_owned() {
+  local target="${1:-t:1}" gen pane
+  gen=$(_mosaic_window_generation "$target")
+  [ -n "$gen" ]
+  while IFS= read -r pane; do
+    [ "$(_mosaic_pane_owner_generation "$pane")" = "$gen" ]
+  done < <(_mosaic_t list-panes -t "$target" -F '#{pane_id}')
+}
+
+@test "ownership bootstrap: single-pane window gets generation and owns its sole pane" {
+  local pane gen
+  _mosaic_use_layout master-stack
+  _mosaic_wait_window_generation_set t:1
+  _mosaic_wait_window_state managed t:1
+
+  pane=$(_mosaic_pane_id_at t:1.1)
+  gen=$(_mosaic_window_generation t:1)
+  [ -n "$gen" ]
+  [ "$(_mosaic_pane_owner_generation "$pane")" = "$gen" ]
+}
+
+@test "ownership bootstrap: multi-pane window adopts current panes when metadata is absent" {
+  for _ in 1 2 3; do _mosaic_split; done
+  [ -z "$(_mosaic_window_generation t:1)" ]
+
+  _mosaic_use_layout master-stack
+  _mosaic_wait_window_generation_set t:1
+  _mosaic_wait_window_state managed t:1
+
+  assert_all_panes_owned t:1
+}
+
+@test "ownership move: pane moved into another window stays foreign there" {
+  local src_pane src_gen dst_gen
+  _mosaic_split
+  _mosaic_use_layout master-stack
+  _mosaic_wait_window_generation_set t:1
+  _mosaic_wait_window_state managed t:1
+
+  src_pane=$(_mosaic_pane_id_at t:1.2)
+  src_gen=$(_mosaic_window_generation t:1)
+  [ "$(_mosaic_pane_owner_generation "$src_pane")" = "$src_gen" ]
+
+  _mosaic_t new-window -d -t t: -n other "sleep 3600"
+  _mosaic_use_layout master-stack t:2
+  _mosaic_wait_window_generation_set t:2
+  _mosaic_wait_window_state managed t:2
+  dst_gen=$(_mosaic_window_generation t:2)
+  [ "$src_gen" != "$dst_gen" ]
+
+  _mosaic_t join-pane -s "$src_pane" -t t:2.1
+  _mosaic_wait_pane_count 1 t:1
+  _mosaic_wait_pane_count 2 t:2
+
+  [ "$(_mosaic_pane_owner_generation "$src_pane")" = "$src_gen" ]
+  [ "$(_mosaic_pane_owner_generation "$src_pane")" != "$dst_gen" ]
+}
+
+@test "ownership move: pane owner metadata survives cross-session moves" {
+  local pane gen
+  _mosaic_split
+  _mosaic_use_layout master-stack
+  _mosaic_wait_window_generation_set t:1
+  _mosaic_wait_window_state managed t:1
+
+  pane=$(_mosaic_pane_id_at t:1.2)
+  gen=$(_mosaic_window_generation t:1)
+  [ "$(_mosaic_pane_owner_generation "$pane")" = "$gen" ]
+
+  _mosaic_t new-session -d -s u -x 200 -y 50 "sleep 3600"
+  _mosaic_t join-pane -s "$pane" -t u:1.1
+  _mosaic_wait_until 3000 \
+    bash -c "[ \"\$(tmux -L $(_mosaic_socket) list-panes -t u:1 -F '#{pane_id}' | grep -c '$pane')\" = '1' ]"
+
+  [ "$(_mosaic_pane_owner_generation "$pane")" = "$gen" ]
+}
+
+@test "ownership state: linked windows share generation and layout state" {
+  local win gen
+  _mosaic_use_layout master-stack
+  _mosaic_wait_window_generation_set t:1
+  _mosaic_wait_window_state managed t:1
+
+  win=$(_mosaic_t list-windows -t t -F '#{window_id}' | head -n1)
+  gen=$(_mosaic_window_generation t:1)
+  _mosaic_t new-session -d -s u -x 200 -y 50 "sleep 3600"
+  _mosaic_t link-window -s t:1 -t u:2
+
+  [ "$(_mosaic_t display-message -p -t u:2 '#{window_id}')" = "$win" ]
+  [ "$(_mosaic_window_generation u:2)" = "$gen" ]
+  [ "$(_mosaic_window_state u:2)" = "managed" ]
+  [ "$(_mosaic_t show-option -wqv -t u:2 @mosaic-layout)" = "master-stack" ]
+}
+
+@test "ownership cleanup: disabling Mosaic clears window and pane ownership state" {
+  local pane
+  for _ in 1 2; do _mosaic_split; done
+  _mosaic_use_layout master-stack
+  _mosaic_wait_window_generation_set t:1
+  _mosaic_wait_window_state managed t:1
+
+  _mosaic_disable_layout
+  _mosaic_wait_window_generation_empty t:1
+  _mosaic_wait_window_state "" t:1
+
+  [ -z "$(_mosaic_window_generation t:1)" ]
+  [ -z "$(_mosaic_window_state t:1)" ]
+  while IFS= read -r pane; do
+    [ -z "$(_mosaic_pane_owner_generation "$pane")" ]
+  done < <(_mosaic_t list-panes -t t:1 -F '#{pane_id}')
+}


### PR DESCRIPTION
## Problem

Mosaic only tracks layout state at the window level, so managed windows have no durable pane ownership metadata or bootstrap path for existing panes.

## Solution

Add window generation and pane owner-generation state, bootstrap ownership when a managed window is first used, clear ownership when Mosaic is disabled, and cover the bootstrap and pane-move invariants with integration tests.
