### PR TITLE
fix(policy): add auto-apply modes for foreign panes

### DIFF
--- a/scripts/defaults.sh
+++ b/scripts/defaults.sh
@@ -3,6 +3,7 @@
 _mosaic_set_defaults() {
   tmux set-option -gwq "@mosaic-orientation" "left"
   tmux set-option -gwq "@mosaic-nmaster" "1"
+  tmux set-option -gwq "@mosaic-auto-apply" "full"
   tmux set-option -gq "@mosaic-mfact" "50"
   tmux set-option -gq "@mosaic-step" "5"
   tmux set-option -gq "@mosaic-debug" "0"

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -84,6 +84,20 @@ _mosaic_enabled() {
   _mosaic_window_has_layout "$target"
 }
 
+_mosaic_auto_apply_for() {
+  local target="${1:-}" val
+  val=$(_mosaic_get_w "@mosaic-auto-apply" "full" "$target")
+  case "$val" in
+  full | managed | none)
+    printf '%s\n' "$val"
+    ;;
+  *)
+    _mosaic_log "auto-apply: invalid=$val target=$target defaulting=full"
+    printf '%s\n' "full"
+    ;;
+  esac
+}
+
 _mosaic_current_window() { tmux display-message -p '#{window_id}'; }
 
 _mosaic_resolve_window() {
@@ -187,6 +201,26 @@ _mosaic_window_foreign_panes() {
   done < <(_mosaic_window_panes "$win")
 }
 
+_mosaic_window_has_owned_panes() {
+  local win pane
+  win=$(_mosaic_resolve_window "${1:-}")
+  while IFS= read -r pane; do
+    [[ -n "$pane" ]] || continue
+    return 0
+  done < <(_mosaic_window_owned_panes "$win")
+  return 1
+}
+
+_mosaic_window_has_foreign_panes() {
+  local win pane
+  win=$(_mosaic_resolve_window "${1:-}")
+  while IFS= read -r pane; do
+    [[ -n "$pane" ]] || continue
+    return 0
+  done < <(_mosaic_window_foreign_panes "$win")
+  return 1
+}
+
 _mosaic_window_adopt_current_panes() {
   local win generation pane
   win=$(_mosaic_resolve_window "${1:-}")
@@ -196,6 +230,18 @@ _mosaic_window_adopt_current_panes() {
     _mosaic_pane_owner_generation_set "$pane" "$generation"
   done < <(_mosaic_window_panes "$win")
   _mosaic_window_state_set "$win" "managed"
+}
+
+_mosaic_window_refresh_state() {
+  local win
+  win=$(_mosaic_resolve_window "${1:-}")
+  if _mosaic_window_has_foreign_panes "$win"; then
+    _mosaic_window_state_set "$win" "suspended"
+  elif _mosaic_window_has_owned_panes "$win"; then
+    _mosaic_window_state_set "$win" "managed"
+  else
+    _mosaic_window_state_unset "$win"
+  fi
 }
 
 _mosaic_window_bootstrap_ownership() {

--- a/scripts/ops.sh
+++ b/scripts/ops.sh
@@ -79,6 +79,24 @@ relayout | _on-set-option | _sync-state | promote | resize-master)
   ;;
 esac
 
+case "$cmd" in
+relayout | _sync-state)
+  auto_apply=$(_mosaic_auto_apply_for "$target_window")
+  case "$auto_apply" in
+  none)
+    exit 0
+    ;;
+  full)
+    _mosaic_window_adopt_current_panes "$target_window"
+    ;;
+  managed)
+    _mosaic_window_refresh_state "$target_window"
+    [[ "$(_mosaic_window_state_get "$target_window")" == "suspended" ]] && exit 0
+    ;;
+  esac
+  ;;
+esac
+
 if [[ "$cmd" == "_on-set-option" ]]; then
   fingerprint=$(_mosaic_compute_fingerprint "$target_window" "$layout")
   pending=$(_mosaic_pending_fingerprint_get "$target_window")

--- a/tests/integration/auto_apply_policy.bats
+++ b/tests/integration/auto_apply_policy.bats
@@ -1,0 +1,98 @@
+#!/usr/bin/env bats
+
+load '../helpers.bash'
+
+setup() {
+  _mosaic_setup_server
+  _mosaic_use_layout master-stack
+  _mosaic_wait_window_generation_set t:1
+  _mosaic_wait_window_state managed t:1
+}
+
+teardown() {
+  _mosaic_teardown_server
+}
+
+reset_log() { _mosaic_reset_log; }
+relayout_count() { _mosaic_log_relayout_count; }
+sync_count() { _mosaic_log_sync_count; }
+
+raw_split() {
+  local target="${1:-t:1}" before
+  before=$(_mosaic_pane_count "$target")
+  _mosaic_t split-window -t "$target" "sleep 3600"
+  _mosaic_wait_pane_count_gt "$before" "$target"
+  _mosaic_quiesce
+}
+
+last_pane_id() {
+  _mosaic_t list-panes -t "${1:-t:1}" -F '#{pane_id}' | tail -n1
+}
+
+@test "auto-apply full: raw split adopts the new pane" {
+  local gen pane
+  _mosaic_t set-option -wq -t t:1 "@mosaic-auto-apply" "full"
+  gen=$(_mosaic_window_generation t:1)
+  reset_log
+
+  raw_split t:1
+  pane=$(last_pane_id t:1)
+
+  _mosaic_wait_pane_owner_generation "$pane" "$gen"
+  [ "$(_mosaic_window_state t:1)" = "managed" ]
+  [ "$(relayout_count)" -ge 1 ]
+}
+
+@test "auto-apply managed: raw split suspends and leaves the new pane foreign" {
+  local pane
+  _mosaic_t set-option -wq -t t:1 "@mosaic-auto-apply" "managed"
+  reset_log
+
+  raw_split t:1
+  pane=$(last_pane_id t:1)
+
+  _mosaic_wait_window_state suspended t:1
+  _mosaic_wait_pane_owner_generation "$pane" ""
+  [ "$(relayout_count)" -eq 0 ]
+}
+
+@test "auto-apply managed: suspended windows do not sync mfact from foreign panes" {
+  _mosaic_t set-option -wq -t t:1 "@mosaic-auto-apply" "managed"
+  _mosaic_t set-option -wq -t t:1 "@mosaic-mfact" "50"
+  raw_split t:1
+  _mosaic_wait_window_state suspended t:1
+  reset_log
+
+  _mosaic_t resize-pane -t t:1.1 -x 160
+  _mosaic_quiesce
+
+  [ "$(_mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "50" ]
+  [ "$(sync_count)" -eq 0 ]
+  [ "$(relayout_count)" -eq 0 ]
+}
+
+@test "auto-apply managed: killing the last foreign pane clears suspension" {
+  local pane
+  _mosaic_t set-option -wq -t t:1 "@mosaic-auto-apply" "managed"
+  raw_split t:1
+  pane=$(last_pane_id t:1)
+  _mosaic_wait_window_state suspended t:1
+
+  _mosaic_t kill-pane -t "$pane"
+  _mosaic_wait_pane_count 1 t:1
+  _mosaic_wait_window_state managed t:1
+
+  [ "$(_mosaic_window_state t:1)" = "managed" ]
+}
+
+@test "auto-apply none: raw split does not relayout or adopt the new pane" {
+  local pane
+  _mosaic_t set-option -wq -t t:1 "@mosaic-auto-apply" "none"
+  reset_log
+
+  raw_split t:1
+  pane=$(last_pane_id t:1)
+
+  _mosaic_wait_pane_owner_generation "$pane" ""
+  [ "$(relayout_count)" -eq 0 ]
+}


### PR DESCRIPTION
## Problem

Mosaic always auto-applies structural relayout hooks today, so raw tmux splits in managed windows get folded into the layout instead of being treated conservatively as foreign panes.

## Solution

Add the `@mosaic-auto-apply` policy with `full`, `managed`, and `none`, suspend managed windows when foreign panes appear, suppress structural relayout and sync while suspended, and cover the new split/kill/sync policy with integration tests.
