### PR TITLE
feat(op): add a managed new-pane action

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -113,6 +113,19 @@ _mosaic_window_zoomed() {
   tmux display-message -p -t "$(_mosaic_resolve_window "${1:-}")" '#{window_zoomed_flag}'
 }
 
+_mosaic_window_structural_guard_get() {
+  _mosaic_get_w_raw "@mosaic-_structural-guard" "${1:-}"
+}
+
+_mosaic_window_structural_guard_set() {
+  local win="$1" token="$2"
+  tmux set-option -wq -t "$win" "@mosaic-_structural-guard" "$token"
+}
+
+_mosaic_window_structural_guard_unset() {
+  tmux set-option -wqu -t "$1" "@mosaic-_structural-guard" 2>/dev/null
+}
+
 _mosaic_window_generation_get() {
   _mosaic_get_w_raw "@mosaic-_generation" "${1:-}"
 }
@@ -353,6 +366,25 @@ _mosaic_show_message() {
   else
     printf '%s\n' "$message" >&2
   fi
+}
+
+_mosaic_current_pane() { tmux display-message -p '#{pane_id}'; }
+
+_mosaic_current_pane_path() {
+  tmux display-message -p -t "${1:-$(_mosaic_current_pane)}" '#{pane_current_path}'
+}
+
+_mosaic_new_pane_default() {
+  local target_pane current_path pane
+  target_pane=$(_mosaic_current_pane)
+  current_path=$(_mosaic_current_pane_path "$target_pane")
+  if [[ -n "$current_path" ]]; then
+    pane=$(tmux split-window -P -F '#{pane_id}' -t "$target_pane" -c "$current_path")
+  else
+    pane=$(tmux split-window -P -F '#{pane_id}' -t "$target_pane")
+  fi
+  [[ -n "$pane" ]] || return 1
+  printf '%s\n' "$pane"
 }
 
 _mosaic_can_relayout_window() {

--- a/scripts/ops.sh
+++ b/scripts/ops.sh
@@ -29,6 +29,10 @@ WIN_ARG=""
 CHANGED_OPT=""
 case "$cmd" in
 relayout | _sync-state)
+  if [[ -n "$(_mosaic_window_structural_guard_get "$target_window")" ]]; then
+    _mosaic_window_structural_guard_unset "$target_window"
+    exit 0
+  fi
   WIN_ARG="${1:-}"
   ;;
 _on-set-option)
@@ -54,7 +58,7 @@ if [[ -z "$layout" ]]; then
     exit 0
     ;;
   relayout | _sync-state) exit 0 ;;
-  toggle | promote | resize-master)
+  toggle | new-pane | promote | resize-master)
     _mosaic_show_message "mosaic: no layout configured"
     exit 0
     ;;
@@ -65,7 +69,7 @@ load_layout "$layout"
 load_rc=$?
 if [[ $load_rc -ne 0 ]]; then
   case "$cmd" in
-  relayout | toggle | promote | resize-master) show_load_error "$load_rc" "$layout" ;;
+  relayout | toggle | new-pane | promote | resize-master) show_load_error "$load_rc" "$layout" ;;
   _on-set-option)
     [[ "$CHANGED_OPT" == "@mosaic-layout" ]] && show_load_error "$load_rc" "$layout"
     ;;
@@ -126,6 +130,28 @@ _sync-state)
     _layout_sync_state "$target_window"
   fi
   ;;
+new-pane)
+  if [[ "$(_mosaic_window_state_get "$target_window")" == "suspended" ]]; then
+    _mosaic_show_message "mosaic: window is suspended; adopt panes first"
+    exit 1
+  fi
+  _mosaic_window_structural_guard_set "$target_window" "$RANDOM-$$"
+  if declare -f _layout_new_pane >/dev/null; then
+    pane=$(_layout_new_pane "$target_window")
+  else
+    pane=$(_mosaic_new_pane_default)
+  fi
+  rc=$?
+  if [[ "$rc" -ne 0 || -z "$pane" ]]; then
+    _mosaic_window_structural_guard_unset "$target_window"
+    exit "${rc:-1}"
+  fi
+  generation=$(_mosaic_window_generation_ensure "$target_window")
+  _mosaic_pane_owner_generation_set "$pane" "$generation"
+  _mosaic_window_state_set "$target_window" "managed"
+  _layout_relayout "$target_window"
+  printf '%s\n' "$pane"
+  ;;
 promote) dispatch_optional _layout_promote ;;
 resize-master) dispatch_optional _layout_resize_master "$@" ;;
 '')
@@ -139,7 +165,7 @@ resize-master) dispatch_optional _layout_resize_master "$@" ;;
 esac
 
 case "$cmd" in
-relayout | _on-set-option | promote)
+relayout | _on-set-option | promote | new-pane)
   applied_fingerprint=$(_mosaic_compute_fingerprint "$target_window" "$layout")
   _mosaic_fingerprint_set "$target_window" "$applied_fingerprint"
   _mosaic_pending_fingerprint_unset "$target_window"

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -96,6 +96,10 @@ _mosaic_pane_id_at() {
   _mosaic_t display-message -p -t "${1:?index required}" '#{pane_id}'
 }
 
+_mosaic_pane_current_path() {
+  _mosaic_t display-message -p -t "${1:?target required}" '#{pane_current_path}'
+}
+
 _mosaic_pane_index() {
   _mosaic_t display-message -p -t "${1:-t:1}" '#{pane_index}'
 }
@@ -275,6 +279,12 @@ _mosaic_wait_pane_count_gt() {
   local min="${1:?min required}" target="${2:-t:1}" timeout="${3:-3000}"
   _mosaic_wait_until "$timeout" \
     bash -c "[ \"\$(tmux -L $(_mosaic_socket) display-message -p -t '$target' '#{window_panes}' 2>/dev/null || echo 0)\" -gt $min ]"
+}
+
+_mosaic_wait_pane_present() {
+  local pane="${1:?pane required}" target="${2:-t:1}" timeout="${3:-3000}"
+  _mosaic_wait_until "$timeout" \
+    bash -c "[ \"\$(tmux -L $(_mosaic_socket) list-panes -t '$target' -F '#{pane_id}' | grep -c '^$pane\$')\" = '1' ]"
 }
 
 _mosaic_wait_pane_left_gt() {

--- a/tests/integration/new_pane.bats
+++ b/tests/integration/new_pane.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+
+load '../helpers.bash'
+
+setup() {
+  _mosaic_setup_server
+  _mosaic_use_layout master-stack
+  _mosaic_wait_window_generation_set t:1
+  _mosaic_wait_window_state managed t:1
+}
+
+teardown() {
+  _mosaic_teardown_server
+}
+
+reset_log() { _mosaic_reset_log; }
+relayout_count() { _mosaic_log_relayout_count; }
+
+@test "new-pane: creates an owned pane without suspending a managed window" {
+  local pane gen
+  _mosaic_t set-option -wq -t t:1 "@mosaic-auto-apply" "managed"
+  gen=$(_mosaic_window_generation t:1)
+  reset_log
+
+  run _mosaic_exec_direct new-pane
+  [ "$status" -eq 0 ]
+  pane="$output"
+  [[ "$pane" == %* ]]
+
+  _mosaic_wait_pane_present "$pane" t:1
+  _mosaic_wait_pane_owner_generation "$pane" "$gen"
+  _mosaic_wait_window_state managed t:1
+
+  [ "$(_mosaic_pane_count t:1)" -eq 2 ]
+  [ "$(relayout_count)" -eq 1 ]
+}
+
+@test "new-pane: preserves the current pane path" {
+  local before pane after
+  before=$(_mosaic_pane_current_path t:1.1)
+
+  run _mosaic_exec_direct new-pane
+  [ "$status" -eq 0 ]
+  pane="$output"
+
+  _mosaic_wait_pane_present "$pane" t:1
+  after=$(_mosaic_pane_current_path "$pane")
+  [ "$after" = "$before" ]
+}
+
+@test "new-pane: explicit op still works when auto-apply is none" {
+  local pane gen
+  _mosaic_t set-option -wq -t t:1 "@mosaic-auto-apply" "none"
+  gen=$(_mosaic_window_generation t:1)
+  reset_log
+
+  run _mosaic_exec_direct new-pane
+  [ "$status" -eq 0 ]
+  pane="$output"
+
+  _mosaic_wait_pane_present "$pane" t:1
+  _mosaic_wait_pane_owner_generation "$pane" "$gen"
+  _mosaic_wait_window_state managed t:1
+  [ "$(_mosaic_pane_count t:1)" -eq 2 ]
+  [ "$(relayout_count)" -eq 1 ]
+}


### PR DESCRIPTION
## Problem

Mosaic has no explicit pane-creation command today, so users have to rely on raw `split-window` behavior and cannot create a pane that is owned immediately without racing the structural split hook.

## Solution

Add a managed `new-pane` op that preserves the current pane path, creates and stamps the new pane as owned before one explicit relayout, and suppresses the background split hook race so managed and `none` policy windows stay stable. Closes #63.
