### PR TITLE
feat(layout): define new-pane insertion semantics

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -387,6 +387,19 @@ _mosaic_new_pane_default() {
   printf '%s\n' "$pane"
 }
 
+_mosaic_new_pane_append() {
+  local win="$1" pane idx pbase n end
+  pane=$(_mosaic_new_pane_default) || return 1
+  idx=$(_mosaic_current_pane_index)
+  pbase=$(_mosaic_current_pane_base)
+  n=$(_mosaic_window_pane_count "$win")
+  end=$((pbase + n - 1))
+  if [[ "$idx" -ne "$end" ]]; then
+    _mosaic_bubble_keep_focus "$idx" "$end"
+  fi
+  printf '%s\n' "$pane"
+}
+
 _mosaic_can_relayout_window() {
   local win="$1" n="$2"
   if ! _mosaic_enabled "$win"; then

--- a/scripts/layouts/centered-master.sh
+++ b/scripts/layouts/centered-master.sh
@@ -165,6 +165,7 @@ _layout_relayout() {
 }
 
 _layout_toggle() { _mosaic_toggle_window; }
+_layout_new_pane() { _mosaic_new_pane_append "$1"; }
 
 _layout_promote() {
   local idx n win nmaster pbase master_base stack_top

--- a/scripts/layouts/dwindle.sh
+++ b/scripts/layouts/dwindle.sh
@@ -4,6 +4,7 @@ _layout_fibonacci_variant() { printf '%s\n' "dwindle"; }
 
 _layout_relayout() { _mosaic_fibonacci_relayout "$@"; }
 _layout_toggle() { _mosaic_toggle_window; }
+_layout_new_pane() { _mosaic_new_pane_append "$1"; }
 _layout_promote() { _mosaic_fibonacci_promote; }
 _layout_resize_master() { _mosaic_fibonacci_resize_master "$@"; }
 _layout_sync_state() { _mosaic_fibonacci_sync_state "$1"; }

--- a/scripts/layouts/even-horizontal.sh
+++ b/scripts/layouts/even-horizontal.sh
@@ -3,3 +3,4 @@
 _layout_relayout() { _mosaic_relayout_simple even-horizontal "${1:-}"; }
 
 _layout_toggle() { _mosaic_toggle_window; }
+_layout_new_pane() { _mosaic_new_pane_append "$1"; }

--- a/scripts/layouts/even-vertical.sh
+++ b/scripts/layouts/even-vertical.sh
@@ -3,3 +3,4 @@
 _layout_relayout() { _mosaic_relayout_simple even-vertical "${1:-}"; }
 
 _layout_toggle() { _mosaic_toggle_window; }
+_layout_new_pane() { _mosaic_new_pane_append "$1"; }

--- a/scripts/layouts/grid.sh
+++ b/scripts/layouts/grid.sh
@@ -3,3 +3,4 @@
 _layout_relayout() { _mosaic_relayout_simple tiled "${1:-}"; }
 
 _layout_toggle() { _mosaic_toggle_window; }
+_layout_new_pane() { _mosaic_new_pane_append "$1"; }

--- a/scripts/layouts/master-stack.sh
+++ b/scripts/layouts/master-stack.sh
@@ -86,6 +86,7 @@ _layout_relayout() {
 }
 
 _layout_toggle() { _mosaic_toggle_window; }
+_layout_new_pane() { _mosaic_new_pane_append "$1"; }
 
 _layout_promote() {
   local idx n pbase

--- a/scripts/layouts/monocle.sh
+++ b/scripts/layouts/monocle.sh
@@ -14,3 +14,4 @@ _layout_relayout() {
 }
 
 _layout_toggle() { _mosaic_toggle_window; }
+_layout_new_pane() { _mosaic_new_pane_append "$1"; }

--- a/scripts/layouts/spiral.sh
+++ b/scripts/layouts/spiral.sh
@@ -4,6 +4,7 @@ _layout_fibonacci_variant() { printf '%s\n' "spiral"; }
 
 _layout_relayout() { _mosaic_fibonacci_relayout "$@"; }
 _layout_toggle() { _mosaic_toggle_window; }
+_layout_new_pane() { _mosaic_new_pane_append "$1"; }
 _layout_promote() { _mosaic_fibonacci_promote; }
 _layout_resize_master() { _mosaic_fibonacci_resize_master "$@"; }
 _layout_sync_state() { _mosaic_fibonacci_sync_state "$1"; }

--- a/scripts/layouts/three-column.sh
+++ b/scripts/layouts/three-column.sh
@@ -138,6 +138,7 @@ _layout_relayout() {
 }
 
 _layout_toggle() { _mosaic_toggle_window; }
+_layout_new_pane() { _mosaic_new_pane_append "$1"; }
 
 _layout_promote() {
   local idx n win nmaster pbase stack_top

--- a/tests/integration/new_pane_layouts.bats
+++ b/tests/integration/new_pane_layouts.bats
@@ -1,0 +1,67 @@
+#!/usr/bin/env bats
+
+load '../helpers.bash'
+
+setup() {
+  _mosaic_setup_server
+}
+
+teardown() {
+  _mosaic_teardown_server
+}
+
+assert_new_pane_appends_to_end() {
+  local layout="${1:?layout required}" splits="${2:?split count required}" pane
+  _mosaic_use_layout "$layout"
+  for ((i = 0; i < splits; i++)); do
+    _mosaic_split
+  done
+  _mosaic_t select-pane -t t:1.1
+
+  run _mosaic_exec_direct new-pane
+  [ "$status" -eq 0 ]
+  pane="$output"
+
+  _mosaic_wait_pane_present "$pane" t:1
+  [ "$(last_pane_id)" = "$pane" ]
+}
+
+last_pane_id() {
+  _mosaic_t list-panes -t t:1 -F '#{pane_id}' | tail -n1
+}
+
+@test "master-stack: new-pane appends to the stack end" {
+  assert_new_pane_appends_to_end master-stack 3
+}
+
+@test "centered-master: new-pane appends to the pane order end" {
+  assert_new_pane_appends_to_end centered-master 4
+}
+
+@test "three-column: new-pane appends to the pane order end" {
+  assert_new_pane_appends_to_end three-column 4
+}
+
+@test "spiral: new-pane appends to the pane order end" {
+  assert_new_pane_appends_to_end spiral 3
+}
+
+@test "dwindle: new-pane appends to the pane order end" {
+  assert_new_pane_appends_to_end dwindle 3
+}
+
+@test "grid: new-pane appends to the pane order end" {
+  assert_new_pane_appends_to_end grid 3
+}
+
+@test "even-vertical: new-pane appends to the pane order end" {
+  assert_new_pane_appends_to_end even-vertical 3
+}
+
+@test "even-horizontal: new-pane appends to the pane order end" {
+  assert_new_pane_appends_to_end even-horizontal 3
+}
+
+@test "monocle: new-pane appends to the pane order end" {
+  assert_new_pane_appends_to_end monocle 3
+}


### PR DESCRIPTION
## Problem

`new-pane` exists now, but without layout-specific insertion semantics it still inherits the focused pane's raw split position instead of following each layout's own pane-order model.

## Solution

Define `new-pane` insertion semantics for every supported layout by appending the Mosaic-created pane to the end of the layout pane order before relayout, and cover the common insertion path across all layouts with integration tests. Closes #82.
