### PR TITLE
feat(op): add adopt to reclaim current panes

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -187,6 +187,14 @@ _mosaic_window_generation_ensure() {
   printf '%s\n' "$generation"
 }
 
+_mosaic_window_generation_rotate() {
+  local win generation
+  win=$(_mosaic_resolve_window "${1:-}")
+  generation=$(_mosaic_window_generation_new "$win")
+  _mosaic_window_generation_set "$win" "$generation"
+  printf '%s\n' "$generation"
+}
+
 _mosaic_pane_is_owned_by_window() {
   local pane="$1" win generation owner_generation
   win=$(_mosaic_resolve_window "${2:-}")
@@ -234,14 +242,29 @@ _mosaic_window_has_foreign_panes() {
   return 1
 }
 
-_mosaic_window_adopt_current_panes() {
+_mosaic_window_stamp_current_panes() {
   local win generation pane
   win=$(_mosaic_resolve_window "${1:-}")
-  generation=$(_mosaic_window_generation_ensure "$win")
+  generation="${2:?generation required}"
   while IFS= read -r pane; do
     [[ -n "$pane" ]] || continue
     _mosaic_pane_owner_generation_set "$pane" "$generation"
   done < <(_mosaic_window_panes "$win")
+}
+
+_mosaic_window_adopt_current_panes() {
+  local win generation
+  win=$(_mosaic_resolve_window "${1:-}")
+  generation=$(_mosaic_window_generation_ensure "$win")
+  _mosaic_window_stamp_current_panes "$win" "$generation"
+  _mosaic_window_state_set "$win" "managed"
+}
+
+_mosaic_window_adopt_current_panes_refresh() {
+  local win generation
+  win=$(_mosaic_resolve_window "${1:-}")
+  generation=$(_mosaic_window_generation_rotate "$win")
+  _mosaic_window_stamp_current_panes "$win" "$generation"
   _mosaic_window_state_set "$win" "managed"
 }
 
@@ -366,6 +389,10 @@ _mosaic_show_message() {
   else
     printf '%s\n' "$message" >&2
   fi
+}
+
+_mosaic_show_suspended_message() {
+  _mosaic_show_message "mosaic: window is suspended; adopt panes first"
 }
 
 _mosaic_current_pane() { tmux display-message -p '#{pane_id}'; }

--- a/scripts/ops.sh
+++ b/scripts/ops.sh
@@ -58,7 +58,7 @@ if [[ -z "$layout" ]]; then
     exit 0
     ;;
   relayout | _sync-state) exit 0 ;;
-  toggle | new-pane | promote | resize-master)
+  toggle | new-pane | adopt | promote | resize-master)
     _mosaic_show_message "mosaic: no layout configured"
     exit 0
     ;;
@@ -69,7 +69,7 @@ load_layout "$layout"
 load_rc=$?
 if [[ $load_rc -ne 0 ]]; then
   case "$cmd" in
-  relayout | toggle | new-pane | promote | resize-master) show_load_error "$load_rc" "$layout" ;;
+  relayout | toggle | new-pane | adopt | promote | resize-master) show_load_error "$load_rc" "$layout" ;;
   _on-set-option)
     [[ "$CHANGED_OPT" == "@mosaic-layout" ]] && show_load_error "$load_rc" "$layout"
     ;;
@@ -78,13 +78,25 @@ if [[ $load_rc -ne 0 ]]; then
 fi
 
 case "$cmd" in
-relayout | _on-set-option | _sync-state | promote | resize-master)
+relayout | _on-set-option | _sync-state | new-pane | adopt | promote | resize-master)
   _mosaic_window_bootstrap_ownership "$target_window"
   ;;
 esac
 
+force_relayout=0
+if [[ "$cmd" == "_on-set-option" && "$CHANGED_OPT" == "@mosaic-layout" && -n "$local_layout" ]]; then
+  if _mosaic_window_has_foreign_panes "$target_window" || ! _mosaic_window_has_owned_panes "$target_window"; then
+    _mosaic_window_adopt_current_panes_refresh "$target_window"
+    force_relayout=1
+  fi
+fi
+
 case "$cmd" in
 relayout | _sync-state)
+  if [[ -n "$(_mosaic_window_structural_guard_get "$target_window")" ]]; then
+    _mosaic_window_structural_guard_unset "$target_window"
+    exit 0
+  fi
   auto_apply=$(_mosaic_auto_apply_for "$target_window")
   case "$auto_apply" in
   none)
@@ -105,7 +117,7 @@ if [[ "$cmd" == "_on-set-option" ]]; then
   fingerprint=$(_mosaic_compute_fingerprint "$target_window" "$layout")
   pending=$(_mosaic_pending_fingerprint_get "$target_window")
   cached="${pending:-$(_mosaic_fingerprint_get "$target_window")}"
-  if [[ -n "$cached" && "$cached" == "$fingerprint" ]]; then
+  if [[ "$force_relayout" != "1" && -n "$cached" && "$cached" == "$fingerprint" ]]; then
     exit 0
   fi
   _mosaic_pending_fingerprint_set "$target_window" "$fingerprint"
@@ -132,7 +144,7 @@ _sync-state)
   ;;
 new-pane)
   if [[ "$(_mosaic_window_state_get "$target_window")" == "suspended" ]]; then
-    _mosaic_show_message "mosaic: window is suspended; adopt panes first"
+    _mosaic_show_suspended_message
     exit 1
   fi
   _mosaic_window_structural_guard_set "$target_window" "$RANDOM-$$"
@@ -152,8 +164,21 @@ new-pane)
   _layout_relayout "$target_window"
   printf '%s\n' "$pane"
   ;;
-promote) dispatch_optional _layout_promote ;;
-resize-master) dispatch_optional _layout_resize_master "$@" ;;
+adopt)
+  _mosaic_window_adopt_current_panes_refresh "$target_window"
+  _layout_relayout "$target_window"
+  ;;
+promote | resize-master)
+  if [[ "$(_mosaic_window_state_get "$target_window")" == "suspended" ]]; then
+    _mosaic_show_suspended_message
+    exit 1
+  fi
+  if [[ "$cmd" == "promote" ]]; then
+    dispatch_optional _layout_promote
+  else
+    dispatch_optional _layout_resize_master "$@"
+  fi
+  ;;
 '')
   echo "usage: $0 <op> [args]" >&2
   exit 1
@@ -165,7 +190,7 @@ resize-master) dispatch_optional _layout_resize_master "$@" ;;
 esac
 
 case "$cmd" in
-relayout | _on-set-option | promote | new-pane)
+relayout | _on-set-option | promote | new-pane | adopt)
   applied_fingerprint=$(_mosaic_compute_fingerprint "$target_window" "$layout")
   _mosaic_fingerprint_set "$target_window" "$applied_fingerprint"
   _mosaic_pending_fingerprint_unset "$target_window"

--- a/tests/integration/adopt.bats
+++ b/tests/integration/adopt.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+
+load '../helpers.bash'
+
+setup() {
+  _mosaic_setup_server
+  _mosaic_use_layout master-stack
+  _mosaic_wait_window_generation_set t:1
+  _mosaic_wait_window_state managed t:1
+}
+
+teardown() {
+  _mosaic_teardown_server
+}
+
+reset_log() { _mosaic_reset_log; }
+relayout_count() { _mosaic_log_relayout_count; }
+
+assert_all_panes_owned() {
+  local target="${1:-t:1}" gen pane
+  gen=$(_mosaic_window_generation "$target")
+  [ -n "$gen" ]
+  while IFS= read -r pane; do
+    [ "$(_mosaic_pane_owner_generation "$pane")" = "$gen" ]
+  done < <(_mosaic_t list-panes -t "$target" -F '#{pane_id}')
+}
+
+suspend_window_with_foreign_pane() {
+  _mosaic_t set-option -wq -t t:1 "@mosaic-auto-apply" "managed"
+  _mosaic_t split-window -t t:1 "sleep 3600"
+  _mosaic_wait_pane_count 2 t:1
+  _mosaic_wait_window_state suspended t:1
+}
+
+@test "adopt: suspended window adopts all current panes and relayouts once" {
+  local old_gen
+  suspend_window_with_foreign_pane
+  old_gen=$(_mosaic_window_generation t:1)
+  reset_log
+
+  run _mosaic_exec_direct adopt
+  [ "$status" -eq 0 ]
+
+  _mosaic_wait_window_state managed t:1
+  [ "$(_mosaic_window_generation t:1)" != "$old_gen" ]
+  assert_all_panes_owned t:1
+  [ "$(relayout_count)" -eq 1 ]
+}
+
+@test "adopt: already managed window rotates ownership without breaking it" {
+  local old_gen
+  _mosaic_split
+  old_gen=$(_mosaic_window_generation t:1)
+
+  run _mosaic_exec_direct adopt
+  [ "$status" -eq 0 ]
+
+  _mosaic_wait_window_state managed t:1
+  [ "$(_mosaic_window_generation t:1)" != "$old_gen" ]
+  assert_all_panes_owned t:1
+}
+
+@test "promote: suspended window refuses cleanly" {
+  suspend_window_with_foreign_pane
+
+  run _mosaic_exec_direct promote
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"mosaic: window is suspended; adopt panes first"* ]]
+}
+
+@test "resize-master: suspended window refuses cleanly" {
+  suspend_window_with_foreign_pane
+
+  run _mosaic_exec_direct resize-master +5
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"mosaic: window is suspended; adopt panes first"* ]]
+}
+
+@test "explicit local layout change adopts panes and clears suspension" {
+  local old_gen
+  suspend_window_with_foreign_pane
+  old_gen=$(_mosaic_window_generation t:1)
+
+  _mosaic_t set-option -wq -t t:1 "@mosaic-layout" "grid"
+  _mosaic_wait_layout_outer '[' t:1
+  _mosaic_wait_window_state managed t:1
+
+  [ "$(_mosaic_window_generation t:1)" != "$old_gen" ]
+  assert_all_panes_owned t:1
+}


### PR DESCRIPTION
## Problem

Managed mode can suspend a window when foreign panes appear, but there is no explicit recovery path to reclaim the current pane set or to refuse layout-mutation ops cleanly while the window is suspended.

## Solution

Add an `adopt` op that rotates the ownership generation and reclaims all current panes, block suspended `promote` and `resize-master` ops with a clear message, and let explicit local layout changes adopt panes when a suspended window needs recovery. Closes #83.
