### PR TITLE
fix(test): stabilize async relayout synchronization

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -126,6 +126,29 @@ _mosaic_window_structural_guard_unset() {
   tmux set-option -wqu -t "$1" "@mosaic-_structural-guard" 2>/dev/null
 }
 
+_mosaic_window_async_token_get() {
+  _mosaic_get_w_raw "@mosaic-_async-token" "${1:-}"
+}
+
+_mosaic_window_async_token_set() {
+  local win="$1" token="$2"
+  tmux set-option -wq -t "$win" "@mosaic-_async-token" "$token"
+}
+
+_mosaic_window_async_token_issue() {
+  local win token
+  win=$(_mosaic_resolve_window "${1:-}")
+  token="${win}:$(date +%s%N):$$:$RANDOM"
+  _mosaic_window_async_token_set "$win" "$token"
+  printf '%s\n' "$token"
+}
+
+_mosaic_window_async_token_matches() {
+  local win="$1" token="$2"
+  [[ -n "$token" ]] || return 1
+  [[ "$(_mosaic_window_async_token_get "$win")" == "$token" ]]
+}
+
 _mosaic_window_generation_get() {
   _mosaic_get_w_raw "@mosaic-_generation" "${1:-}"
 }
@@ -248,24 +271,58 @@ _mosaic_window_stamp_current_panes() {
   generation="${2:?generation required}"
   while IFS= read -r pane; do
     [[ -n "$pane" ]] || continue
+    if ! _mosaic_window_has_layout "$win"; then
+      _mosaic_window_ownership_clear "$win"
+      return 1
+    fi
     _mosaic_pane_owner_generation_set "$pane" "$generation"
   done < <(_mosaic_window_panes "$win")
+  if ! _mosaic_window_has_layout "$win"; then
+    _mosaic_window_ownership_clear "$win"
+    return 1
+  fi
 }
 
 _mosaic_window_adopt_current_panes() {
   local win generation
   win=$(_mosaic_resolve_window "${1:-}")
+  _mosaic_window_has_layout "$win" || return 1
   generation=$(_mosaic_window_generation_ensure "$win")
-  _mosaic_window_stamp_current_panes "$win" "$generation"
+  if ! _mosaic_window_has_layout "$win"; then
+    _mosaic_window_ownership_clear "$win"
+    return 1
+  fi
+  _mosaic_window_stamp_current_panes "$win" "$generation" || return 1
+  if ! _mosaic_window_has_layout "$win"; then
+    _mosaic_window_ownership_clear "$win"
+    return 1
+  fi
   _mosaic_window_state_set "$win" "managed"
+  if ! _mosaic_window_has_layout "$win"; then
+    _mosaic_window_ownership_clear "$win"
+    return 1
+  fi
 }
 
 _mosaic_window_adopt_current_panes_refresh() {
   local win generation
   win=$(_mosaic_resolve_window "${1:-}")
+  _mosaic_window_has_layout "$win" || return 1
   generation=$(_mosaic_window_generation_rotate "$win")
-  _mosaic_window_stamp_current_panes "$win" "$generation"
+  if ! _mosaic_window_has_layout "$win"; then
+    _mosaic_window_ownership_clear "$win"
+    return 1
+  fi
+  _mosaic_window_stamp_current_panes "$win" "$generation" || return 1
+  if ! _mosaic_window_has_layout "$win"; then
+    _mosaic_window_ownership_clear "$win"
+    return 1
+  fi
   _mosaic_window_state_set "$win" "managed"
+  if ! _mosaic_window_has_layout "$win"; then
+    _mosaic_window_ownership_clear "$win"
+    return 1
+  fi
 }
 
 _mosaic_window_refresh_state() {

--- a/scripts/ops.sh
+++ b/scripts/ops.sh
@@ -29,10 +29,6 @@ WIN_ARG=""
 CHANGED_OPT=""
 case "$cmd" in
 relayout | _sync-state)
-  if [[ -n "$(_mosaic_window_structural_guard_get "$target_window")" ]]; then
-    _mosaic_window_structural_guard_unset "$target_window"
-    exit 0
-  fi
   WIN_ARG="${1:-}"
   ;;
 _on-set-option)
@@ -42,6 +38,27 @@ _on-set-option)
 esac
 
 target_window=$(_mosaic_resolve_window "$WIN_ARG")
+case "$cmd" in
+relayout | _sync-state)
+  if [[ -n "$(_mosaic_window_structural_guard_get "$target_window")" ]]; then
+    _mosaic_window_structural_guard_unset "$target_window"
+    exit 0
+  fi
+  ;;
+esac
+
+async_token=""
+case "$cmd" in
+relayout | _sync-state | _on-set-option)
+  async_token=$(_mosaic_window_async_token_issue "$target_window")
+  ;;
+esac
+
+ensure_current() {
+  [[ -z "$async_token" ]] && return 0
+  _mosaic_window_async_token_matches "$target_window" "$async_token"
+}
+
 local_layout=$(_mosaic_local_layout "$target_window")
 layout=$(_mosaic_layout_for_window "$target_window")
 
@@ -52,6 +69,7 @@ fi
 if [[ -z "$layout" ]]; then
   case "$cmd" in
   _on-set-option)
+    ensure_current || exit 0
     _mosaic_window_ownership_clear "$target_window"
     _mosaic_fingerprint_unset "$target_window"
     _mosaic_pending_fingerprint_unset "$target_window"
@@ -77,6 +95,7 @@ if [[ $load_rc -ne 0 ]]; then
   exit 1
 fi
 
+ensure_current || exit 0
 case "$cmd" in
 relayout | _on-set-option | _sync-state | new-pane | adopt | promote | resize-master)
   _mosaic_window_bootstrap_ownership "$target_window"
@@ -85,18 +104,17 @@ esac
 
 force_relayout=0
 if [[ "$cmd" == "_on-set-option" && "$CHANGED_OPT" == "@mosaic-layout" && -n "$local_layout" ]]; then
+  ensure_current || exit 0
   if _mosaic_window_has_foreign_panes "$target_window" || ! _mosaic_window_has_owned_panes "$target_window"; then
     _mosaic_window_adopt_current_panes_refresh "$target_window"
+    ensure_current || exit 0
     force_relayout=1
   fi
 fi
 
 case "$cmd" in
 relayout | _sync-state)
-  if [[ -n "$(_mosaic_window_structural_guard_get "$target_window")" ]]; then
-    _mosaic_window_structural_guard_unset "$target_window"
-    exit 0
-  fi
+  ensure_current || exit 0
   auto_apply=$(_mosaic_auto_apply_for "$target_window")
   case "$auto_apply" in
   none)
@@ -104,9 +122,11 @@ relayout | _sync-state)
     ;;
   full)
     _mosaic_window_adopt_current_panes "$target_window"
+    ensure_current || exit 0
     ;;
   managed)
     _mosaic_window_refresh_state "$target_window"
+    ensure_current || exit 0
     [[ "$(_mosaic_window_state_get "$target_window")" == "suspended" ]] && exit 0
     ;;
   esac
@@ -114,6 +134,7 @@ relayout | _sync-state)
 esac
 
 if [[ "$cmd" == "_on-set-option" ]]; then
+  ensure_current || exit 0
   fingerprint=$(_mosaic_compute_fingerprint "$target_window" "$layout")
   pending=$(_mosaic_pending_fingerprint_get "$target_window")
   cached="${pending:-$(_mosaic_fingerprint_get "$target_window")}"
@@ -121,6 +142,7 @@ if [[ "$cmd" == "_on-set-option" ]]; then
     exit 0
   fi
   _mosaic_pending_fingerprint_set "$target_window" "$fingerprint"
+  ensure_current || exit 0
 fi
 
 dispatch_optional() {
@@ -134,6 +156,7 @@ dispatch_optional() {
   fi
 }
 
+ensure_current || exit 0
 case "$cmd" in
 relayout | _on-set-option) _layout_relayout "$target_window" ;;
 toggle) _layout_toggle ;;
@@ -190,7 +213,8 @@ promote | resize-master)
 esac
 
 case "$cmd" in
-relayout | _on-set-option | promote | new-pane | adopt)
+relayout | _on-set-option | _sync-state | promote | new-pane | adopt)
+  ensure_current || exit 0
   applied_fingerprint=$(_mosaic_compute_fingerprint "$target_window" "$layout")
   _mosaic_fingerprint_set "$target_window" "$applied_fingerprint"
   _mosaic_pending_fingerprint_unset "$target_window"

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -6,14 +6,26 @@ _mosaic_test_id() {
   printf '%s\n' "${BATS_TEST_FILENAME:-}:${BATS_TEST_NAME:-}:${BATS_SUITE_TEST_NUMBER:-${BATS_TEST_NUMBER:-0}}" | cksum | awk '{print $1}'
 }
 
+_mosaic_test_instance_id() {
+  if [[ -n "${BATS_TEST_TMPDIR:-}" ]]; then
+    printf '%s\n' "$BATS_TEST_TMPDIR" | cksum | awk '{print $1}'
+  else
+    _mosaic_test_id
+  fi
+}
+
 _mosaic_socket() {
-  echo "${MOSAIC_TEST_SOCKET:-mosaic-test}-$(_mosaic_test_id)"
+  echo "${MOSAIC_TEST_SOCKET:-mosaic-test}-$(_mosaic_test_instance_id)"
 }
 
 _mosaic_t() { tmux -L "$(_mosaic_socket)" "$@"; }
 
 _mosaic_test_tmpdir() {
-  echo "${TMPDIR:-/tmp}/tmux-mosaic-tests/$(_mosaic_test_id)"
+  if [[ -n "${BATS_TEST_TMPDIR:-}" ]]; then
+    printf '%s\n' "$BATS_TEST_TMPDIR"
+  else
+    echo "${TMPDIR:-/tmp}/tmux-mosaic-tests/$(_mosaic_test_id)"
+  fi
 }
 
 _mosaic_log_file() {
@@ -196,7 +208,7 @@ _mosaic_wait_log_quiet() {
 }
 
 _mosaic_reset_log() {
-  _mosaic_wait_log_quiet 600 100
+  _mosaic_quiesce
   : >"$(_mosaic_log_file)"
 }
 

--- a/tests/integration/adopt.bats
+++ b/tests/integration/adopt.bats
@@ -7,6 +7,7 @@ setup() {
   _mosaic_use_layout master-stack
   _mosaic_wait_window_generation_set t:1
   _mosaic_wait_window_state managed t:1
+  _mosaic_wait_option_set @mosaic-_fingerprint t:1
 }
 
 teardown() {

--- a/tests/integration/auto_apply_policy.bats
+++ b/tests/integration/auto_apply_policy.bats
@@ -31,14 +31,16 @@ last_pane_id() {
 }
 
 @test "auto-apply full: raw split adopts the new pane" {
-  local gen pane
+  local gen pane fp
   _mosaic_t set-option -wq -t t:1 "@mosaic-auto-apply" "full"
   gen=$(_mosaic_window_generation t:1)
+  fp=$(_mosaic_fingerprint t:1)
   reset_log
 
   raw_split t:1
   pane=$(last_pane_id t:1)
 
+  _mosaic_wait_fingerprint_changed_from "$fp" t:1
   _mosaic_wait_pane_owner_generation "$pane" "$gen"
   [ "$(_mosaic_window_state t:1)" = "managed" ]
   [ "$(relayout_count)" -ge 1 ]

--- a/tests/integration/auto_apply_policy.bats
+++ b/tests/integration/auto_apply_policy.bats
@@ -7,6 +7,7 @@ setup() {
   _mosaic_use_layout master-stack
   _mosaic_wait_window_generation_set t:1
   _mosaic_wait_window_state managed t:1
+  _mosaic_wait_option_set @mosaic-_fingerprint t:1
 }
 
 teardown() {

--- a/tests/integration/centered_master.bats
+++ b/tests/integration/centered_master.bats
@@ -127,9 +127,11 @@ pane_field() {
 @test "centered-master: kill-pane keeps the master centered on relayout" {
   for _ in 1 2 3 4; do _mosaic_split; done
   [ "$(_mosaic_pane_count)" = "5" ]
+  fp=$(_mosaic_fingerprint t:1)
 
   _mosaic_t kill-pane -t t:1.4
   _mosaic_wait_pane_count_gt 0 t:1.4
+  _mosaic_wait_fingerprint_changed_from "$fp" t:1
   _mosaic_quiesce
 
   [ "$(_mosaic_pane_count)" = "4" ]

--- a/tests/integration/dwindle.bats
+++ b/tests/integration/dwindle.bats
@@ -112,9 +112,11 @@ pane_field() {
 @test "dwindle: kill-pane keeps the recursive shape" {
   for _ in 1 2 3 4 5; do _mosaic_split; done
   [ "$(_mosaic_pane_count)" = "6" ]
+  fp=$(_mosaic_fingerprint t:1)
 
   _mosaic_t kill-pane -t t:1.5
   _mosaic_wait_pane_count_gt 0 t:1.5
+  _mosaic_wait_fingerprint_changed_from "$fp" t:1
   _mosaic_quiesce
 
   [ "$(_mosaic_pane_count)" = "5" ]

--- a/tests/integration/master_stack.bats
+++ b/tests/integration/master_stack.bats
@@ -293,8 +293,10 @@ assert_orientation_layout() {
 @test "kill stack pane: hook auto-rebalances stack" {
   for _ in 1 2 3 4; do _mosaic_split; done
   [ "$(_mosaic_pane_count)" = "5" ]
+  fp=$(_mosaic_fingerprint t:1)
   _mosaic_t kill-pane -t t:1.3
   _mosaic_wait_pane_count_gt 0 t:1.3
+  _mosaic_wait_fingerprint_changed_from "$fp" t:1
   _mosaic_quiesce
   [ "$(_mosaic_pane_count)" = "4" ]
   pane2_h=$(_mosaic_t list-panes -F '#{pane_index} #{pane_height}' | awk '$1==2{print $2}')
@@ -307,8 +309,10 @@ assert_orientation_layout() {
   for _ in 1 2; do _mosaic_split; done
   [ "$(_mosaic_pane_count)" = "3" ]
   stack_top=$(_mosaic_pane_id_at t:1.2)
+  fp=$(_mosaic_fingerprint t:1)
   _mosaic_t kill-pane -t t:1.1
   _mosaic_wait_pane_count_gt 0 t:1.1
+  _mosaic_wait_fingerprint_changed_from "$fp" t:1
   _mosaic_quiesce
   [ "$(_mosaic_pane_count)" = "2" ]
   [ "$(_mosaic_pane_id_at t:1.1)" = "$stack_top" ]

--- a/tests/integration/master_stack.bats
+++ b/tests/integration/master_stack.bats
@@ -437,8 +437,10 @@ assert_orientation_layout() {
 
 @test "drag-resize: master width survives next split" {
   _mosaic_split
+  _mosaic_reset_log
   _mosaic_t resize-pane -t t:1.1 -x 160
   _mosaic_wait_option @mosaic-mfact 80 t:1
+  _mosaic_wait_relayout_count_ge 1
   [ "$(_mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "80" ]
 
   _mosaic_split
@@ -450,9 +452,13 @@ assert_orientation_layout() {
 @test "drag-resize with nmaster 2 syncs mfact from the master region" {
   set_nmaster t:1 2
   for _ in 1 2; do _mosaic_split; done
+  _mosaic_reset_log
   _mosaic_t resize-pane -t t:1.1 -x 120
-  _mosaic_wait_option @mosaic-mfact 60 t:1
-  [ "$(_mosaic_t show-option -wqv -t t:1 @mosaic-mfact)" = "60" ]
+  _mosaic_wait_option_changed_from @mosaic-mfact 50 t:1
+  _mosaic_wait_relayout_count_ge 1
+  mfact=$(_mosaic_t show-option -wqv -t t:1 @mosaic-mfact)
+  [ "$mfact" -ge 59 ]
+  [ "$mfact" -le 61 ]
 
   _mosaic_split
   pane1_w=$(pane_field t:1 1 4)

--- a/tests/integration/monocle.bats
+++ b/tests/integration/monocle.bats
@@ -5,6 +5,8 @@ load '../helpers.bash'
 setup() {
   _mosaic_setup_server
   _mosaic_t set-option -wq -t t:1 "@mosaic-layout" "monocle"
+  _mosaic_wait_option_set @mosaic-_fingerprint t:1
+  _mosaic_quiesce
 }
 
 teardown() {

--- a/tests/integration/new_pane_layouts.bats
+++ b/tests/integration/new_pane_layouts.bats
@@ -13,6 +13,7 @@ teardown() {
 assert_new_pane_appends_to_end() {
   local layout="${1:?layout required}" splits="${2:?split count required}" pane
   _mosaic_use_layout "$layout"
+  _mosaic_wait_option_set @mosaic-_fingerprint t:1
   for ((i = 0; i < splits; i++)); do
     _mosaic_split
   done

--- a/tests/integration/option_hook.bats
+++ b/tests/integration/option_hook.bats
@@ -185,9 +185,11 @@ assert_relayout_count() {
 }
 
 @test "no double relayout: drag-resize sync triggers one relayout" {
+  fp=$(_mosaic_fingerprint t:1)
   reset_log
   _mosaic_t resize-pane -t t:1.1 -x 160
   _mosaic_wait_log_match 'sync-state:'
+  _mosaic_wait_fingerprint_changed_from "$fp" t:1
 
   _mosaic_quiesce
   [ "$(sync_count)" -eq 1 ]

--- a/tests/integration/option_hook.bats
+++ b/tests/integration/option_hook.bats
@@ -185,15 +185,12 @@ assert_relayout_count() {
 }
 
 @test "no double relayout: drag-resize sync triggers one relayout" {
-  fp=$(_mosaic_fingerprint t:1)
   reset_log
   _mosaic_t resize-pane -t t:1.1 -x 160
   _mosaic_wait_log_match 'sync-state:'
-  _mosaic_wait_fingerprint_changed_from "$fp" t:1
 
-  _mosaic_quiesce
+  assert_relayout_count 1
   [ "$(sync_count)" -eq 1 ]
-  [ "$(relayout_count)" -eq 1 ]
 }
 
 @test "after-set-option: set @mosaic-layout to off preserves layout" {

--- a/tests/integration/spiral.bats
+++ b/tests/integration/spiral.bats
@@ -109,9 +109,11 @@ pane_field() {
 @test "spiral: kill-pane keeps the recursive shape" {
   for _ in 1 2 3 4; do _mosaic_split; done
   [ "$(_mosaic_pane_count)" = "5" ]
+  fp=$(_mosaic_fingerprint t:1)
 
   _mosaic_t kill-pane -t t:1.4
   _mosaic_wait_pane_count_gt 0 t:1.4
+  _mosaic_wait_fingerprint_changed_from "$fp" t:1
   _mosaic_quiesce
 
   [ "$(_mosaic_pane_count)" = "4" ]

--- a/tests/integration/three_column.bats
+++ b/tests/integration/three_column.bats
@@ -128,9 +128,11 @@ pane_field() {
 @test "three-column: kill-pane keeps the three-column shape" {
   for _ in 1 2 3 4; do _mosaic_split; done
   [ "$(_mosaic_pane_count)" = "5" ]
+  fp=$(_mosaic_fingerprint t:1)
 
   _mosaic_t kill-pane -t t:1.3
   _mosaic_wait_pane_count_gt 0 t:1.3
+  _mosaic_wait_fingerprint_changed_from "$fp" t:1
   _mosaic_quiesce
 
   [ "$(_mosaic_pane_count)" = "4" ]


### PR DESCRIPTION
## Problem

Issue #95 tracks remaining CI flakes caused by async hook work racing ownership updates, relayout completion, and the barriers the Bats suite was waiting on.

## Solution

Guard async `relayout`, `_sync-state`, and `_on-set-option` work with window-scoped tokens, clear ownership when a layout disappears during adoption, persist the final fingerprint after `_sync-state`, and tighten the timing-sensitive integration tests and helpers to wait on the specific transitions they actually depend on.