### PR TITLE
docs(readme): move dwindle after spiral

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,59 +164,6 @@ bind U set-option -wqu @mosaic-layout
 </details>
 
 <details>
-<summary><code>dwindle</code> — shrinking Fibonacci sibling of spiral</summary>
-
-### Behavior
-
-This is the shrinking sibling of `spiral`, following the dwm fibonacci
-`dwindle` layout. The first pane gets a master region on the left sized by
-`@mosaic-mfact`, and the remaining panes recurse through the leftover space in
-a steadily shrinking bottom-right pattern. `promote` bubbles the focused pane
-into the master slot, `resize-master` changes the first split, and
-drag-resizing that master boundary syncs back into `@mosaic-mfact`.
-
-### Preview
-
-![dwindle layout preview](https://github.com/user-attachments/assets/8b583c94-da5e-4e96-808c-669b3657f820)
-
-### Core actions
-
-| Command                        | Behavior                                                                  |
-| ------------------------------ | ------------------------------------------------------------------------- |
-| `toggle`                       | Turn `dwindle` off on the current window.                                 |
-| `relayout`                     | Re-apply the current shrinking Fibonacci layout with the current `@mosaic-mfact`. |
-| `new-pane`                     | Create an owned pane and append it to the end of pane order so it becomes the newest leaf in the dwindle pattern. |
-| `promote`                      | Focused pane becomes the master pane. On the master pane, rotate the next pane forward. |
-| `resize-master ±N`             | Change the first split width for the current window, clamped to 5–95.     |
-| `select-pane -t :.-` (builtin) | Focus the previous pane in tmux pane order.                               |
-| `select-pane -t :.+` (builtin) | Focus the next pane in tmux pane order.                                   |
-| `swap-pane -U` (builtin)       | Move the current pane earlier in tmux pane order.                         |
-| `swap-pane -D` (builtin)       | Move the current pane later in tmux pane order.                           |
-| `split-window` (builtin)       | Add a pane and rebalance the recursive dwindle pattern.                   |
-| `kill-pane` (builtin)          | Remove a pane and rebalance the recursive dwindle pattern.                |
-| `resize-pane` (builtin)        | Resize the master pane live, then sync the new width back into `@mosaic-mfact`. |
-
-### Relevant options
-
-| Option          | Scope         | Default | Effect                                              |
-| --------------- | ------------- | ------- | --------------------------------------------------- |
-| `@mosaic-mfact` | window→global | `50`    | Stores the master-split width as a percent         |
-| `@mosaic-step`  | global        | `5`     | Used by `resize-master` when you call it without N  |
-
-### Example config
-
-```tmux
-bind D set-option -wq @mosaic-layout dwindle
-bind Enter run '#{E:@mosaic-exec} promote'
-bind -r , run '#{E:@mosaic-exec} resize-master -5'
-bind -r . run '#{E:@mosaic-exec} resize-master +5'
-bind T run '#{E:@mosaic-exec} toggle'
-bind U set-option -wqu @mosaic-layout
-```
-
-</details>
-
-<details>
 <summary><code>centered-master</code> — center master with side stacks</summary>
 
 ### Behavior
@@ -367,6 +314,59 @@ drag-resizing that master boundary syncs back into `@mosaic-mfact`.
 
 ```tmux
 bind S set-option -wq @mosaic-layout spiral
+bind Enter run '#{E:@mosaic-exec} promote'
+bind -r , run '#{E:@mosaic-exec} resize-master -5'
+bind -r . run '#{E:@mosaic-exec} resize-master +5'
+bind T run '#{E:@mosaic-exec} toggle'
+bind U set-option -wqu @mosaic-layout
+```
+
+</details>
+
+<details>
+<summary><code>dwindle</code> — shrinking Fibonacci sibling of spiral</summary>
+
+### Behavior
+
+This is the shrinking sibling of `spiral`, following the dwm fibonacci
+`dwindle` layout. The first pane gets a master region on the left sized by
+`@mosaic-mfact`, and the remaining panes recurse through the leftover space in
+a steadily shrinking bottom-right pattern. `promote` bubbles the focused pane
+into the master slot, `resize-master` changes the first split, and
+drag-resizing that master boundary syncs back into `@mosaic-mfact`.
+
+### Preview
+
+![dwindle layout preview](https://github.com/user-attachments/assets/8b583c94-da5e-4e96-808c-669b3657f820)
+
+### Core actions
+
+| Command                        | Behavior                                                                  |
+| ------------------------------ | ------------------------------------------------------------------------- |
+| `toggle`                       | Turn `dwindle` off on the current window.                                 |
+| `relayout`                     | Re-apply the current shrinking Fibonacci layout with the current `@mosaic-mfact`. |
+| `new-pane`                     | Create an owned pane and append it to the end of pane order so it becomes the newest leaf in the dwindle pattern. |
+| `promote`                      | Focused pane becomes the master pane. On the master pane, rotate the next pane forward. |
+| `resize-master ±N`             | Change the first split width for the current window, clamped to 5–95.     |
+| `select-pane -t :.-` (builtin) | Focus the previous pane in tmux pane order.                               |
+| `select-pane -t :.+` (builtin) | Focus the next pane in tmux pane order.                                   |
+| `swap-pane -U` (builtin)       | Move the current pane earlier in tmux pane order.                         |
+| `swap-pane -D` (builtin)       | Move the current pane later in tmux pane order.                           |
+| `split-window` (builtin)       | Add a pane and rebalance the recursive dwindle pattern.                   |
+| `kill-pane` (builtin)          | Remove a pane and rebalance the recursive dwindle pattern.                |
+| `resize-pane` (builtin)        | Resize the master pane live, then sync the new width back into `@mosaic-mfact`. |
+
+### Relevant options
+
+| Option          | Scope         | Default | Effect                                              |
+| --------------- | ------------- | ------- | --------------------------------------------------- |
+| `@mosaic-mfact` | window→global | `50`    | Stores the master-split width as a percent         |
+| `@mosaic-step`  | global        | `5`     | Used by `resize-master` when you call it without N  |
+
+### Example config
+
+```tmux
+bind D set-option -wq @mosaic-layout dwindle
 bind Enter run '#{E:@mosaic-exec} promote'
 bind -r , run '#{E:@mosaic-exec} resize-master -5'
 bind -r . run '#{E:@mosaic-exec} resize-master +5'


### PR DESCRIPTION
## Problem

The README currently lists `dwindle` before `spiral`, which makes the two Fibonacci layout sections read in a less natural order.

## Solution

Move the `dwindle` section so it appears immediately after `spiral` without changing any of the README section contents.