### PR TITLE
test(new-pane): codify visual stability acceptance cases

### DIFF
--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -33,6 +33,7 @@ _mosaic_log_file() {
 }
 
 _mosaic_setup_server() {
+  local x="${1:-200}" y="${2:-50}"
   _mosaic_t kill-server 2>/dev/null || true
   mkdir -p "$(_mosaic_test_tmpdir)"
   rm -f "$(_mosaic_log_file)"
@@ -46,7 +47,7 @@ run-shell "$REPO_ROOT/mosaic.tmux"
 set-option -gq @mosaic-debug 1
 set-option -gq @mosaic-log-file "$(_mosaic_log_file)"
 EOF
-  _mosaic_t -f "$conf" new-session -d -s t -x 200 -y 50 "sleep 3600"
+  _mosaic_t -f "$conf" new-session -d -s t -x "$x" -y "$y" "sleep 3600"
   _mosaic_wait_until 3000 \
     bash -c "[ -n \"\$(tmux -L $(_mosaic_socket) show-option -gqv '@mosaic-exec' 2>/dev/null)\" ]"
 }
@@ -93,6 +94,32 @@ _mosaic_split() {
   _mosaic_quiesce
 }
 
+_mosaic_raw_split() {
+  _mosaic_t split-window -P -F '#{pane_id}' "$@" "sleep 3600"
+}
+
+_mosaic_new_pane() {
+  local target="${1:-t:1}" before before_count fp layout pane
+  _mosaic_quiesce
+  before=$(_mosaic_pane_ids "$target")
+  before_count=$(_mosaic_pane_count "$target")
+  fp=$(_mosaic_fingerprint "$target")
+  layout=$(_mosaic_t show-option -wqvA -t "$target" "@mosaic-layout" 2>/dev/null)
+  _mosaic_exec_direct new-pane >/dev/null
+  _mosaic_wait_pane_count_gt "$before_count" "$target"
+  if [[ -n "$layout" && "$layout" != "off" ]]; then
+    if [[ -n "$fp" ]]; then
+      _mosaic_wait_fingerprint_changed_from "$fp" "$target"
+    else
+      _mosaic_wait_option_set "@mosaic-_fingerprint" "$target"
+    fi
+  fi
+  pane=$(_mosaic_new_pane_id_from "$before" "$target") || return 1
+  _mosaic_wait_pane_present "$pane" "$target"
+  _mosaic_quiesce
+  printf '%s\n' "$pane"
+}
+
 _mosaic_socket_path() {
   echo "${TMUX_TMPDIR:-/tmp}/tmux-$(id -u)/$(_mosaic_socket)"
 }
@@ -110,6 +137,31 @@ _mosaic_pane_id_at() {
 
 _mosaic_pane_current_path() {
   _mosaic_t display-message -p -t "${1:?target required}" '#{pane_current_path}'
+}
+
+_mosaic_pane_field() {
+  local target="${1:?target required}" field="${2:?field required}"
+  _mosaic_t display-message -p -t "$target" "#{$field}"
+}
+
+_mosaic_pane_left() {
+  _mosaic_pane_field "${1:?target required}" pane_left
+}
+
+_mosaic_pane_top() {
+  _mosaic_pane_field "${1:?target required}" pane_top
+}
+
+_mosaic_pane_width() {
+  _mosaic_pane_field "${1:?target required}" pane_width
+}
+
+_mosaic_pane_height() {
+  _mosaic_pane_field "${1:?target required}" pane_height
+}
+
+_mosaic_pane_rect() {
+  _mosaic_t display-message -p -t "${1:?target required}" '#{pane_left} #{pane_top} #{pane_width} #{pane_height}'
 }
 
 _mosaic_pane_index() {
@@ -150,6 +202,10 @@ _mosaic_pane_ids() {
   _mosaic_t list-panes -t "${1:-t:1}" -F '#{pane_id}'
 }
 
+_mosaic_last_pane_id() {
+  _mosaic_t list-panes -t "${1:-t:1}" -F '#{pane_id}' | tail -n1
+}
+
 _mosaic_new_pane_id_from() {
   local before="${1-}" target="${2:-t:1}" pane
   while IFS= read -r pane; do
@@ -160,6 +216,20 @@ _mosaic_new_pane_id_from() {
     fi
   done < <(_mosaic_pane_ids "$target")
   return 1
+}
+
+_mosaic_rect_contains() {
+  local outer_left="${1:?outer left required}" outer_top="${2:?outer top required}" outer_width="${3:?outer width required}" outer_height="${4:?outer height required}"
+  local inner_left="${5:?inner left required}" inner_top="${6:?inner top required}" inner_width="${7:?inner width required}" inner_height="${8:?inner height required}"
+  local outer_right inner_right outer_bottom inner_bottom
+  outer_right=$((outer_left + outer_width - 1))
+  inner_right=$((inner_left + inner_width - 1))
+  outer_bottom=$((outer_top + outer_height - 1))
+  inner_bottom=$((inner_top + inner_height - 1))
+  [[ "$inner_left" -ge "$outer_left" &&
+    "$inner_top" -ge "$outer_top" &&
+    "$inner_right" -le "$outer_right" &&
+    "$inner_bottom" -le "$outer_bottom" ]]
 }
 
 _mosaic_layout_outer() {

--- a/tests/integration/new_pane_acceptance.bats
+++ b/tests/integration/new_pane_acceptance.bats
@@ -1,0 +1,154 @@
+#!/usr/bin/env bats
+
+load '../helpers.bash'
+
+setup() {
+  _mosaic_setup_server
+}
+
+teardown() {
+  _mosaic_teardown_server
+}
+
+setup_layout() {
+  local layout="${1:?layout required}" splits="${2:?split count required}"
+  _mosaic_use_layout "$layout"
+  _mosaic_wait_option_set @mosaic-_fingerprint t:1
+  for ((i = 0; i < splits; i++)); do
+    _mosaic_split
+  done
+}
+
+@test "new-pane acceptance: dwindle tail growth is an exact local split" {
+  local first second third tail pane
+  local first_rect second_rect third_rect
+  local left top width height new_left new_top new_width new_height
+
+  setup_layout dwindle 3
+  first=$(_mosaic_pane_id_at t:1.1)
+  second=$(_mosaic_pane_id_at t:1.2)
+  third=$(_mosaic_pane_id_at t:1.3)
+  tail=$(_mosaic_pane_id_at t:1.4)
+  first_rect=$(_mosaic_pane_rect "$first")
+  second_rect=$(_mosaic_pane_rect "$second")
+  third_rect=$(_mosaic_pane_rect "$third")
+  read -r left top width height <<<"$(_mosaic_pane_rect "$tail")"
+
+  pane=$(_mosaic_new_pane)
+
+  [ "$(_mosaic_pane_rect "$first")" = "$first_rect" ]
+  [ "$(_mosaic_pane_rect "$second")" = "$second_rect" ]
+  [ "$(_mosaic_pane_rect "$third")" = "$third_rect" ]
+  read -r new_left new_top new_width new_height <<<"$(_mosaic_pane_rect "$pane")"
+  _mosaic_rect_contains "$left" "$top" "$width" "$height" "$new_left" "$new_top" "$new_width" "$new_height"
+}
+
+@test "new-pane acceptance: even-horizontal append equalizes the row" {
+  local first tail pane
+  local first_width
+  local left top width height new_left new_top new_width new_height
+
+  setup_layout even-horizontal 2
+  first=$(_mosaic_pane_id_at t:1.1)
+  tail=$(_mosaic_pane_id_at t:1.3)
+  first_width=$(_mosaic_pane_width "$first")
+  read -r left top width height <<<"$(_mosaic_pane_rect "$tail")"
+
+  pane=$(_mosaic_new_pane)
+
+  read -r new_left new_top new_width new_height <<<"$(_mosaic_pane_rect "$pane")"
+  _mosaic_rect_contains "$left" "$top" "$width" "$height" "$new_left" "$new_top" "$new_width" "$new_height"
+  [ "$(_mosaic_pane_width "$first")" -lt "$first_width" ]
+}
+
+@test "new-pane acceptance: centered-master four-to-five shifts pane roles locally" {
+  local master right
+  local master_left right_left
+
+  setup_layout centered-master 3
+  master=$(_mosaic_pane_id_at t:1.2)
+  right=$(_mosaic_pane_id_at t:1.3)
+  master_left=$(_mosaic_pane_left "$master")
+  right_left=$(_mosaic_pane_left "$right")
+
+  _mosaic_new_pane >/dev/null
+
+  [ "$(_mosaic_pane_left "$master")" -lt "$master_left" ]
+  [ "$(_mosaic_pane_left "$right")" -lt "$right_left" ]
+  [ "$(_mosaic_pane_left "$right")" -eq "$master_left" ]
+}
+
+@test "new-pane acceptance: grid four-to-five is a global reshape" {
+  local first second third fourth pane
+  local first_rect second_rect third_rect fourth_rect
+  local new_left new_top new_width new_height
+
+  setup_layout grid 3
+  first=$(_mosaic_pane_id_at t:1.1)
+  second=$(_mosaic_pane_id_at t:1.2)
+  third=$(_mosaic_pane_id_at t:1.3)
+  fourth=$(_mosaic_pane_id_at t:1.4)
+  first_rect=$(_mosaic_pane_rect "$first")
+  second_rect=$(_mosaic_pane_rect "$second")
+  third_rect=$(_mosaic_pane_rect "$third")
+  fourth_rect=$(_mosaic_pane_rect "$fourth")
+
+  pane=$(_mosaic_new_pane)
+  read -r new_left new_top new_width new_height <<<"$(_mosaic_pane_rect "$pane")"
+
+  ! _mosaic_rect_contains $first_rect "$new_left" "$new_top" "$new_width" "$new_height"
+  ! _mosaic_rect_contains $second_rect "$new_left" "$new_top" "$new_width" "$new_height"
+  ! _mosaic_rect_contains $third_rect "$new_left" "$new_top" "$new_width" "$new_height"
+  ! _mosaic_rect_contains $fourth_rect "$new_left" "$new_top" "$new_width" "$new_height"
+}
+
+@test "new-pane acceptance: tmux cannot get mirrored side and append order from one horizontal split" {
+  local old right left
+
+  old=$(_mosaic_pane_id_at t:1.1)
+
+  right=$(_mosaic_raw_split -h -t t:1.1)
+  _mosaic_wait_pane_present "$right" t:1
+  [ "$(_mosaic_last_pane_id t:1)" = "$right" ]
+  [ "$(_mosaic_pane_left "$right")" -gt "$(_mosaic_pane_left "$old")" ]
+
+  _mosaic_t kill-pane -t "$right"
+  _mosaic_wait_pane_count 1 t:1
+
+  left=$(_mosaic_raw_split -h -b -t t:1.1)
+  _mosaic_wait_pane_present "$left" t:1
+  [ "$(_mosaic_pane_left "$left")" -lt "$(_mosaic_pane_left "$old")" ]
+  [ "$(_mosaic_last_pane_id t:1)" = "$old" ]
+}
+
+@test "new-pane acceptance: monocle snaps zoom and focus to the new pane" {
+  local active_before pane
+
+  setup_layout monocle 2
+  active_before=$(_mosaic_t display-message -p -t t:1 '#{pane_id}')
+  [ "$(_mosaic_t display-message -p -t t:1 '#{window_zoomed_flag}')" = "1" ]
+
+  pane=$(_mosaic_new_pane)
+
+  [ "$(_mosaic_t display-message -p -t t:1 '#{window_zoomed_flag}')" = "1" ]
+  [ "$(_mosaic_t display-message -p -t t:1 '#{pane_id}')" = "$pane" ]
+  [ "$pane" != "$active_before" ]
+}
+
+@test "new-pane acceptance: raw split reports no space on a tiny pane" {
+  local pane
+
+  _mosaic_teardown_server
+  _mosaic_setup_server 10 6
+
+  pane=$(_mosaic_raw_split -h -t t:1.1)
+  _mosaic_wait_pane_present "$pane" t:1
+  pane=$(_mosaic_raw_split -h -t t:1.1)
+  _mosaic_wait_pane_present "$pane" t:1
+  pane=$(_mosaic_raw_split -v -t t:1.1)
+  _mosaic_wait_pane_present "$pane" t:1
+
+  run _mosaic_raw_split -h -t t:1.1
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"no space for new pane"* ]]
+}


### PR DESCRIPTION
## Problem

Issue #101 still needs durable acceptance coverage for the creation-time `new-pane` visual-stability matrix before layout-specific fixes can land.

## Solution

Closes #101 by adding reusable geometry helpers in `tests/helpers.bash` and a representative `tests/integration/new_pane_acceptance.bats` matrix that covers exact local splits, local equalization, local role shifts, global reshapes, mirrored side/order conflicts, zoom snaps, and min-size failures.