### PR TITLE
test(new-pane): add shared targeting primitives

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -194,6 +194,10 @@ _mosaic_window_panes() {
   tmux list-panes -t "$(_mosaic_resolve_window "${1:-}")" -F '#{pane_id}' 2>/dev/null || true
 }
 
+_mosaic_window_last_pane() {
+  _mosaic_window_panes "${1:-}" | tail -n1
+}
+
 _mosaic_window_generation_new() {
   local win="$1"
   printf '%s\n' "${win}:$(date +%s%N):$$:$RANDOM"
@@ -458,28 +462,28 @@ _mosaic_current_pane_path() {
   tmux display-message -p -t "${1:-$(_mosaic_current_pane)}" '#{pane_current_path}'
 }
 
-_mosaic_new_pane_default() {
-  local target_pane current_path pane
-  target_pane=$(_mosaic_current_pane)
-  current_path=$(_mosaic_current_pane_path "$target_pane")
+_mosaic_new_pane_split() {
+  local target_pane="${1:?target pane required}" current_path pane
+  shift
+  current_path=$(_mosaic_current_pane_path)
   if [[ -n "$current_path" ]]; then
-    pane=$(tmux split-window -P -F '#{pane_id}' -t "$target_pane" -c "$current_path")
+    pane=$(tmux split-window "$@" -P -F '#{pane_id}' -t "$target_pane" -c "$current_path")
   else
-    pane=$(tmux split-window -P -F '#{pane_id}' -t "$target_pane")
+    pane=$(tmux split-window "$@" -P -F '#{pane_id}' -t "$target_pane")
   fi
   [[ -n "$pane" ]] || return 1
   printf '%s\n' "$pane"
 }
 
+_mosaic_new_pane_default() { _mosaic_new_pane_split "$(_mosaic_current_pane)"; }
+
 _mosaic_new_pane_append() {
-  local win="$1" pane idx pbase n end
+  local win="$1" pane target_pane last_pane
+  target_pane=$(_mosaic_current_pane)
+  last_pane=$(_mosaic_window_last_pane "$win")
   pane=$(_mosaic_new_pane_default) || return 1
-  idx=$(_mosaic_current_pane_index)
-  pbase=$(_mosaic_current_pane_base)
-  n=$(_mosaic_window_pane_count "$win")
-  end=$((pbase + n - 1))
-  if [[ "$idx" -ne "$end" ]]; then
-    _mosaic_bubble_keep_focus "$idx" "$end"
+  if [[ "$target_pane" != "$last_pane" ]]; then
+    _mosaic_move_keep_focus -s "$pane" -t "$last_pane"
   fi
   printf '%s\n' "$pane"
 }
@@ -540,6 +544,13 @@ _mosaic_swap_keep_focus() {
   local pid
   pid=$(tmux display-message -p '#{pane_id}')
   tmux swap-pane "$@"
+  tmux select-pane -t "$pid"
+}
+
+_mosaic_move_keep_focus() {
+  local pid
+  pid=$(tmux display-message -p '#{pane_id}')
+  tmux move-pane "$@"
   tmux select-pane -t "$pid"
 }
 

--- a/tests/integration/new_pane_primitives.bats
+++ b/tests/integration/new_pane_primitives.bats
@@ -1,0 +1,85 @@
+#!/usr/bin/env bats
+
+load '../helpers.bash'
+
+setup() {
+  _mosaic_setup_server
+}
+
+teardown() {
+  _mosaic_teardown_server
+}
+
+helper_eval() {
+  local cmd="${1:?command required}" sock
+  sock=$(_mosaic_socket_path)
+  TMUX="$sock,$$,0" bash -lc "source '$REPO_ROOT/scripts/helpers.sh'; $cmd"
+}
+
+@test "new-pane helpers: window last pane returns the semantic tail" {
+  local tail
+  _mosaic_t split-window -t t:1 "sleep 3600"
+  _mosaic_wait_pane_count 2 t:1
+  _mosaic_t split-window -t t:1 "sleep 3600"
+  _mosaic_wait_pane_count 3 t:1
+  tail=$(_mosaic_pane_id_at t:1.3)
+
+  run helper_eval "_mosaic_window_last_pane 't:1'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$tail" ]
+}
+
+@test "new-pane helpers: targeted split uses the target pane but the current pane path" {
+  local current_dir target_dir target pane current_rect
+  current_dir="$BATS_TEST_TMPDIR/current"
+  target_dir="$BATS_TEST_TMPDIR/target"
+  mkdir -p "$current_dir" "$target_dir"
+
+  _mosaic_t respawn-pane -k -t t:1.1 -c "$current_dir" "sleep 3600"
+  _mosaic_wait_pane_count 1 t:1
+  _mosaic_t split-window -t t:1.1 -c "$target_dir" "sleep 3600"
+  _mosaic_wait_pane_count 2 t:1
+  _mosaic_t select-pane -t t:1.1
+  target=$(_mosaic_pane_id_at t:1.2)
+  current_rect=$(_mosaic_pane_rect t:1.1)
+  [ "$(_mosaic_pane_current_path "$target")" = "$target_dir" ]
+
+  run helper_eval "_mosaic_new_pane_split '$target'"
+  [ "$status" -eq 0 ]
+  pane="$output"
+
+  _mosaic_wait_pane_present "$pane" t:1
+  [ "$(_mosaic_pane_rect t:1.1)" = "$current_rect" ]
+  [ "$(_mosaic_pane_current_path "$pane")" = "$current_dir" ]
+}
+
+@test "new-pane helpers: targeted split accepts explicit side flags" {
+  local pane original
+  original=$(_mosaic_pane_id_at t:1.1)
+
+  run helper_eval "_mosaic_new_pane_split '$original' -h -b"
+  [ "$status" -eq 0 ]
+  pane="$output"
+
+  _mosaic_wait_pane_present "$pane" t:1
+  [ "$(_mosaic_pane_left "$pane")" = "0" ]
+  [ "$(_mosaic_pane_left "$original")" -gt 0 ]
+}
+
+@test "new-pane helpers: move wrapper preserves focus" {
+  local focus source target
+  _mosaic_t split-window -t t:1 "sleep 3600"
+  _mosaic_wait_pane_count 2 t:1
+  _mosaic_t split-window -t t:1 "sleep 3600"
+  _mosaic_wait_pane_count 3 t:1
+  _mosaic_t select-pane -t t:1.2
+  focus=$(_mosaic_pane_id_at t:1.2)
+  source=$(_mosaic_pane_id_at t:1.1)
+  target=$(_mosaic_pane_id_at t:1.3)
+
+  run helper_eval "_mosaic_move_keep_focus -s '$source' -t '$target'"
+  [ "$status" -eq 0 ]
+
+  [ "$(_mosaic_t display-message -p -t t:1 '#{pane_id}')" = "$focus" ]
+  [ "$(_mosaic_pane_id_at t:1.3)" = "$source" ]
+}


### PR DESCRIPTION
## Problem

Issue #102 needs a shared helper layer for managed `new-pane` targeting and minimal reorder behavior before the layout-specific visual-stability fixes start landing.

## Solution

Closes #102 by adding shared semantic-tail lookup, targeted split and focus-preserving move helpers in `scripts/helpers.sh`, then covering those primitives directly in `tests/integration/new_pane_primitives.bats`.