### PR TITLE
feat(new-pane): target master and side births directly

### DIFF
--- a/scripts/layouts/centered-master.sh
+++ b/scripts/layouts/centered-master.sh
@@ -165,7 +165,17 @@ _layout_relayout() {
 }
 
 _layout_toggle() { _mosaic_toggle_window; }
-_layout_new_pane() { _mosaic_new_pane_append "$1"; }
+_layout_new_pane() {
+  local win n nmaster
+  win=$(_mosaic_resolve_window "${1:-}")
+  n=$(_mosaic_window_pane_count "$win")
+  nmaster=$(_mosaic_nmaster_for "$win")
+  if [[ "$n" -eq 1 && "$nmaster" -eq 1 ]]; then
+    _mosaic_new_pane_split "$(_mosaic_window_last_pane "$win")" -h
+  else
+    _mosaic_new_pane_append "$win"
+  fi
+}
 
 _layout_promote() {
   local idx n win nmaster pbase master_base stack_top

--- a/scripts/layouts/master-stack.sh
+++ b/scripts/layouts/master-stack.sh
@@ -86,7 +86,23 @@ _layout_relayout() {
 }
 
 _layout_toggle() { _mosaic_toggle_window; }
-_layout_new_pane() { _mosaic_new_pane_append "$1"; }
+_layout_new_pane() {
+  local win n nmaster orientation target
+  local -a flags=()
+  win=$(_mosaic_resolve_window "${1:-}")
+  n=$(_mosaic_window_pane_count "$win")
+  nmaster=$(_mosaic_effective_nmaster "$win" "$n")
+  if [[ "$n" -le "$nmaster" ]]; then
+    _mosaic_new_pane_append "$win"
+    return
+  fi
+  orientation=$(_layout_orientation_for "$win")
+  target=$(_mosaic_window_last_pane "$win")
+  case "$orientation" in
+  top | bottom) flags=(-h) ;;
+  esac
+  _mosaic_new_pane_split "$target" "${flags[@]}"
+}
 
 _layout_promote() {
   local idx n pbase

--- a/scripts/layouts/three-column.sh
+++ b/scripts/layouts/three-column.sh
@@ -138,7 +138,17 @@ _layout_relayout() {
 }
 
 _layout_toggle() { _mosaic_toggle_window; }
-_layout_new_pane() { _mosaic_new_pane_append "$1"; }
+_layout_new_pane() {
+  local win n nmaster
+  win=$(_mosaic_resolve_window "${1:-}")
+  n=$(_mosaic_window_pane_count "$win")
+  nmaster=$(_mosaic_nmaster_for "$win")
+  if [[ "$n" -eq 1 && "$nmaster" -eq 1 ]]; then
+    _mosaic_new_pane_split "$(_mosaic_window_last_pane "$win")" -h
+  else
+    _mosaic_new_pane_append "$win"
+  fi
+}
 
 _layout_promote() {
   local idx n win nmaster pbase stack_top

--- a/tests/integration/new_pane_fast_paths.bats
+++ b/tests/integration/new_pane_fast_paths.bats
@@ -17,16 +17,38 @@ layout_new_pane_direct() {
 }
 
 layout_new_pane_signature() {
-  local layout="${1:?layout required}" target="${2:-t:1}"
-  REPO_ROOT="$REPO_ROOT" LAYOUT="$layout" TARGET="$target" bash -lc '
+  local layout="${1:?layout required}" target="${2:-t:1}" setup="${3:-}"
+  REPO_ROOT="$REPO_ROOT" LAYOUT="$layout" TARGET="$target" SETUP="$setup" bash -lc '
     set -euo pipefail
     source "$REPO_ROOT/scripts/helpers.sh"
     _mosaic_window_last_pane() { printf "%s\n" "%9"; }
     _mosaic_new_pane_split() { printf "split:%s\n" "$*"; }
     _mosaic_new_pane_append() { printf "append:%s\n" "$*"; }
     source "$REPO_ROOT/scripts/layouts/$LAYOUT.sh"
+    eval "$SETUP"
     _layout_new_pane "$TARGET"
   '
+}
+
+assert_master_stack_signature() {
+  local orientation="${1:?orientation required}" expected="${2:?expected signature required}" setup
+  setup="_mosaic_window_pane_count() { printf '%s\\n' 3; }
+_mosaic_effective_nmaster() { printf '%s\\n' 1; }
+_layout_orientation_for() { printf '%s\\n' $orientation; }"
+
+  run layout_new_pane_signature master-stack t:1 "$setup"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$expected" ]
+}
+
+assert_single_side_signature() {
+  local layout="${1:?layout required}" expected="${2:?expected signature required}" setup
+  setup="_mosaic_window_pane_count() { printf '%s\\n' 1; }
+_mosaic_nmaster_for() { printf '%s\\n' 1; }"
+
+  run layout_new_pane_signature "$layout" t:1 "$setup"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$expected" ]
 }
 
 last_pane_id() {
@@ -117,4 +139,60 @@ distinct_pane_lefts() {
   _mosaic_wait_pane_present "$pane" t:1
   [ "$(last_pane_id t:1)" = "$pane" ]
   [ "$(distinct_pane_lefts t:1)" = "0" ]
+}
+
+@test "new-pane fast paths: master-stack existing left stack targets the tail directly" {
+  assert_master_stack_signature left "split:%9"
+}
+
+@test "new-pane fast paths: master-stack existing right stack targets the tail directly" {
+  assert_master_stack_signature right "split:%9"
+}
+
+@test "new-pane fast paths: master-stack existing top stack targets the tail directly" {
+  assert_master_stack_signature top "split:%9 -h"
+}
+
+@test "new-pane fast paths: master-stack existing bottom stack targets the tail directly" {
+  assert_master_stack_signature bottom "split:%9 -h"
+}
+
+@test "new-pane fast paths: centered-master targets the first side birth with a horizontal split" {
+  assert_single_side_signature centered-master "split:%9 -h"
+}
+
+@test "new-pane fast paths: centered-master first side-stack pane starts on the right before relayout" {
+  local before pane
+  _mosaic_use_layout centered-master
+  _mosaic_wait_option_set @mosaic-_fingerprint t:1
+  before=$(_mosaic_pane_ids t:1)
+
+  run layout_new_pane_direct centered-master t:1
+  [ "$status" -eq 0 ]
+  pane=$(_mosaic_new_pane_id_from "$before" t:1)
+
+  _mosaic_wait_pane_present "$pane" t:1
+  [ "$(last_pane_id t:1)" = "$pane" ]
+  [ "$(_mosaic_pane_left "$pane")" -gt 0 ]
+  [ "$(_mosaic_pane_top "$pane")" -eq 0 ]
+}
+
+@test "new-pane fast paths: three-column targets the first side birth with a horizontal split" {
+  assert_single_side_signature three-column "split:%9 -h"
+}
+
+@test "new-pane fast paths: three-column first side-column pane starts on the right before relayout" {
+  local before pane
+  _mosaic_use_layout three-column
+  _mosaic_wait_option_set @mosaic-_fingerprint t:1
+  before=$(_mosaic_pane_ids t:1)
+
+  run layout_new_pane_direct three-column t:1
+  [ "$status" -eq 0 ]
+  pane=$(_mosaic_new_pane_id_from "$before" t:1)
+
+  _mosaic_wait_pane_present "$pane" t:1
+  [ "$(last_pane_id t:1)" = "$pane" ]
+  [ "$(_mosaic_pane_left "$pane")" -gt 0 ]
+  [ "$(_mosaic_pane_top "$pane")" -eq 0 ]
 }


### PR DESCRIPTION
## Problem

Issues #105, #106, and #107 cover the next easy layout-aware `new-pane` wins: `master-stack` should target the existing stack tail once the stack exists, and the trivial `1 -> 2` `centered-master` and `three-column` births should start on the correct side instead of going through the generic append path first.

## Solution

Closes #105. Closes #106. Closes #107 by routing the in-scope `master-stack`, `centered-master`, and `three-column` cases through direct shared-helper births and extending `tests/integration/new_pane_fast_paths.bats` to pin both the dispatch semantics and the pre-relayout geometry.