### PR TITLE
feat(new-pane): add recursive tail births for fibonacci layouts

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -656,6 +656,34 @@ _mosaic_fibonacci_layout_step() {
   printf -v "$__next" '%s' "$value_next"
 }
 
+_mosaic_fibonacci_append_phase() {
+  local n="$1" step="${2:-0}"
+  local split order next
+  _mosaic_fibonacci_layout_step split order next "$step"
+  if [[ "$n" -gt 1 && "$order" == "leaf-node" ]]; then
+    _mosaic_fibonacci_append_phase "$((n - 1))" "$next"
+    return
+  fi
+  printf '%s %s\n' "$split" "$order"
+}
+
+_mosaic_fibonacci_new_pane() {
+  local win n split order target
+  local -a flags=()
+  win=$(_mosaic_resolve_window "${1:-}")
+  n=$(_mosaic_window_pane_count "$win")
+  read -r split order <<<"$(_mosaic_fibonacci_append_phase "$n")"
+  if [[ "$order" != "leaf-node" ]]; then
+    _mosaic_new_pane_append "$win"
+    return
+  fi
+  target=$(_mosaic_window_last_pane "$win")
+  case "$split" in
+  master | x) flags=(-h) ;;
+  esac
+  _mosaic_new_pane_split "$target" "${flags[@]}"
+}
+
 _mosaic_fibonacci_layout_node() {
   local __out="$1" sx="$2" sy="$3" x="$4" y="$5" n="$6" step="$7" mfact="$8"
   local split order next axis container

--- a/scripts/layouts/dwindle.sh
+++ b/scripts/layouts/dwindle.sh
@@ -4,7 +4,7 @@ _layout_fibonacci_variant() { printf '%s\n' "dwindle"; }
 
 _layout_relayout() { _mosaic_fibonacci_relayout "$@"; }
 _layout_toggle() { _mosaic_toggle_window; }
-_layout_new_pane() { _mosaic_new_pane_append "$1"; }
+_layout_new_pane() { _mosaic_fibonacci_new_pane "$1"; }
 _layout_promote() { _mosaic_fibonacci_promote; }
 _layout_resize_master() { _mosaic_fibonacci_resize_master "$@"; }
 _layout_sync_state() { _mosaic_fibonacci_sync_state "$1"; }

--- a/scripts/layouts/spiral.sh
+++ b/scripts/layouts/spiral.sh
@@ -4,7 +4,7 @@ _layout_fibonacci_variant() { printf '%s\n' "spiral"; }
 
 _layout_relayout() { _mosaic_fibonacci_relayout "$@"; }
 _layout_toggle() { _mosaic_toggle_window; }
-_layout_new_pane() { _mosaic_new_pane_append "$1"; }
+_layout_new_pane() { _mosaic_fibonacci_new_pane "$1"; }
 _layout_promote() { _mosaic_fibonacci_promote; }
 _layout_resize_master() { _mosaic_fibonacci_resize_master "$@"; }
 _layout_sync_state() { _mosaic_fibonacci_sync_state "$1"; }

--- a/tests/integration/new_pane_fast_paths.bats
+++ b/tests/integration/new_pane_fast_paths.bats
@@ -51,6 +51,15 @@ _mosaic_nmaster_for() { printf '%s\\n' 1; }"
   [ "$output" = "$expected" ]
 }
 
+assert_recursive_signature() {
+  local layout="${1:?layout required}" count="${2:?count required}" expected="${3:?expected signature required}" setup
+  setup="_mosaic_window_pane_count() { printf '%s\\n' $count; }"
+
+  run layout_new_pane_signature "$layout" t:1 "$setup"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$expected" ]
+}
+
 last_pane_id() {
   _mosaic_t list-panes -t "${1:-t:1}" -F '#{pane_id}' | tail -n1
 }
@@ -195,4 +204,78 @@ distinct_pane_lefts() {
   [ "$(last_pane_id t:1)" = "$pane" ]
   [ "$(_mosaic_pane_left "$pane")" -gt 0 ]
   [ "$(_mosaic_pane_top "$pane")" -eq 0 ]
+}
+
+@test "new-pane fast paths: dwindle targets the recursive tail with the master split first" {
+  assert_recursive_signature dwindle 1 "split:%9 -h"
+}
+
+@test "new-pane fast paths: dwindle alternates to a vertical tail split on the third pane" {
+  assert_recursive_signature dwindle 2 "split:%9"
+}
+
+@test "new-pane fast paths: dwindle alternates back to a horizontal tail split on the fourth pane" {
+  assert_recursive_signature dwindle 3 "split:%9 -h"
+}
+
+@test "new-pane fast paths: dwindle 1 -> 2 starts with the new pane on the right before relayout" {
+  local before pane
+  _mosaic_use_layout dwindle
+  _mosaic_wait_option_set @mosaic-_fingerprint t:1
+  before=$(_mosaic_pane_ids t:1)
+
+  run layout_new_pane_direct dwindle t:1
+  [ "$status" -eq 0 ]
+  pane=$(_mosaic_new_pane_id_from "$before" t:1)
+
+  _mosaic_wait_pane_present "$pane" t:1
+  [ "$(last_pane_id t:1)" = "$pane" ]
+  [ "$(_mosaic_pane_left "$pane")" -gt 0 ]
+  [ "$(_mosaic_pane_top "$pane")" -eq 0 ]
+}
+
+@test "new-pane fast paths: spiral targets the first leaf-node birth with the master split" {
+  assert_recursive_signature spiral 1 "split:%9 -h"
+}
+
+@test "new-pane fast paths: spiral targets the second leaf-node birth with a vertical tail split" {
+  assert_recursive_signature spiral 2 "split:%9"
+}
+
+@test "new-pane fast paths: spiral leaves the first node-leaf phase on the append fallback" {
+  assert_recursive_signature spiral 3 "append:t:1"
+}
+
+@test "new-pane fast paths: spiral 1 -> 2 starts with the new pane on the right before relayout" {
+  local before pane
+  _mosaic_use_layout spiral
+  _mosaic_wait_option_set @mosaic-_fingerprint t:1
+  before=$(_mosaic_pane_ids t:1)
+
+  run layout_new_pane_direct spiral t:1
+  [ "$status" -eq 0 ]
+  pane=$(_mosaic_new_pane_id_from "$before" t:1)
+
+  _mosaic_wait_pane_present "$pane" t:1
+  [ "$(last_pane_id t:1)" = "$pane" ]
+  [ "$(_mosaic_pane_left "$pane")" -gt 0 ]
+  [ "$(_mosaic_pane_top "$pane")" -eq 0 ]
+}
+
+@test "new-pane fast paths: spiral 2 -> 3 places the new pane below the tail before relayout" {
+  local before pane old_tail
+  _mosaic_use_layout spiral
+  _mosaic_wait_option_set @mosaic-_fingerprint t:1
+  _mosaic_split t:1
+  old_tail=$(_mosaic_pane_id_at t:1.2)
+  before=$(_mosaic_pane_ids t:1)
+
+  run layout_new_pane_direct spiral t:1
+  [ "$status" -eq 0 ]
+  pane=$(_mosaic_new_pane_id_from "$before" t:1)
+
+  _mosaic_wait_pane_present "$pane" t:1
+  [ "$(last_pane_id t:1)" = "$pane" ]
+  [ "$(_mosaic_pane_left "$pane")" = "$(_mosaic_pane_left "$old_tail")" ]
+  [ "$(_mosaic_pane_top "$pane")" -gt "$(_mosaic_pane_top "$old_tail")" ]
 }


### PR DESCRIPTION
## Problem

Issues #108 and #109 are the first recursive-layout `new-pane` cases where the next pane can often be born directly in the recursive tail instead of going through the generic append path first.

## Solution

Closes #108. Closes #109 by adding a shared Fibonacci birth helper in `scripts/helpers.sh`, using it for `dwindle` and the easy `spiral` leaf-node phases, and extending `tests/integration/new_pane_fast_paths.bats` to pin both the helper dispatch and the pre-relayout geometry. The harder `spiral` node-leaf phases still fall back to append and remain out of scope here.