### PR TITLE
feat(new-pane): reduce column parity-transition churn

### DIFF
--- a/scripts/layouts/centered-master.sh
+++ b/scripts/layouts/centered-master.sh
@@ -166,15 +166,18 @@ _layout_relayout() {
 
 _layout_toggle() { _mosaic_toggle_window; }
 _layout_new_pane() {
-  local win n nmaster
+  local win n nmaster target
+  local -a flags=()
   win=$(_mosaic_resolve_window "${1:-}")
   n=$(_mosaic_window_pane_count "$win")
   nmaster=$(_mosaic_nmaster_for "$win")
-  if [[ "$n" -eq 1 && "$nmaster" -eq 1 ]]; then
-    _mosaic_new_pane_split "$(_mosaic_window_last_pane "$win")" -h
-  else
+  if [[ "$nmaster" -ne 1 ]]; then
     _mosaic_new_pane_append "$win"
+    return
   fi
+  target=$(_mosaic_window_last_pane "$win")
+  [[ "$n" -eq 1 ]] && flags=(-h)
+  _mosaic_new_pane_split "$target" "${flags[@]}"
 }
 
 _layout_promote() {

--- a/scripts/layouts/three-column.sh
+++ b/scripts/layouts/three-column.sh
@@ -139,15 +139,18 @@ _layout_relayout() {
 
 _layout_toggle() { _mosaic_toggle_window; }
 _layout_new_pane() {
-  local win n nmaster
+  local win n nmaster target
+  local -a flags=()
   win=$(_mosaic_resolve_window "${1:-}")
   n=$(_mosaic_window_pane_count "$win")
   nmaster=$(_mosaic_nmaster_for "$win")
-  if [[ "$n" -eq 1 && "$nmaster" -eq 1 ]]; then
-    _mosaic_new_pane_split "$(_mosaic_window_last_pane "$win")" -h
-  else
+  if [[ "$nmaster" -ne 1 ]]; then
     _mosaic_new_pane_append "$win"
+    return
   fi
+  target=$(_mosaic_window_last_pane "$win")
+  [[ "$n" -eq 1 ]] && flags=(-h)
+  _mosaic_new_pane_split "$target" "${flags[@]}"
 }
 
 _layout_promote() {

--- a/tests/integration/new_pane_acceptance.bats
+++ b/tests/integration/new_pane_acceptance.bats
@@ -61,6 +61,23 @@ setup_layout() {
   [ "$(_mosaic_pane_width "$first")" -lt "$first_width" ]
 }
 
+@test "new-pane acceptance: centered-master two-to-three introduces the left stack while keeping the new pane on the right" {
+  local left old_right pane
+  local old_right_left
+
+  setup_layout centered-master 1
+  left=$(_mosaic_pane_id_at t:1.1)
+  old_right=$(_mosaic_pane_id_at t:1.2)
+  old_right_left=$(_mosaic_pane_left "$old_right")
+
+  pane=$(_mosaic_new_pane)
+
+  [ "$(_mosaic_pane_left "$left")" -eq 0 ]
+  [ "$(_mosaic_pane_left "$old_right")" -lt "$old_right_left" ]
+  [ "$(_mosaic_pane_left "$old_right")" -gt "$(_mosaic_pane_left "$left")" ]
+  [ "$(_mosaic_pane_left "$pane")" -gt "$old_right_left" ]
+}
+
 @test "new-pane acceptance: centered-master four-to-five shifts pane roles locally" {
   local master right
   local master_left right_left
@@ -76,6 +93,23 @@ setup_layout() {
   [ "$(_mosaic_pane_left "$master")" -lt "$master_left" ]
   [ "$(_mosaic_pane_left "$right")" -lt "$right_left" ]
   [ "$(_mosaic_pane_left "$right")" -eq "$master_left" ]
+}
+
+@test "new-pane acceptance: three-column three-to-four moves the old right pane into the middle while the new pane stays right" {
+  local middle old_right pane
+  local old_right_left
+
+  setup_layout three-column 2
+  middle=$(_mosaic_pane_id_at t:1.2)
+  old_right=$(_mosaic_pane_id_at t:1.3)
+  old_right_left=$(_mosaic_pane_left "$old_right")
+
+  pane=$(_mosaic_new_pane)
+
+  [ "$(_mosaic_pane_left "$middle")" -gt 0 ]
+  [ "$(_mosaic_pane_left "$old_right")" -lt "$old_right_left" ]
+  [ "$(_mosaic_pane_left "$old_right")" -eq "$(_mosaic_pane_left "$middle")" ]
+  [ "$(_mosaic_pane_left "$pane")" -gt "$(_mosaic_pane_left "$old_right")" ]
 }
 
 @test "new-pane acceptance: grid four-to-five is a global reshape" {

--- a/tests/integration/new_pane_fast_paths.bats
+++ b/tests/integration/new_pane_fast_paths.bats
@@ -51,6 +51,16 @@ _mosaic_nmaster_for() { printf '%s\\n' 1; }"
   [ "$output" = "$expected" ]
 }
 
+assert_default_tail_signature() {
+  local layout="${1:?layout required}" count="${2:?count required}" expected="${3:?expected signature required}" setup
+  setup="_mosaic_window_pane_count() { printf '%s\\n' $count; }
+_mosaic_nmaster_for() { printf '%s\\n' 1; }"
+
+  run layout_new_pane_signature "$layout" t:1 "$setup"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$expected" ]
+}
+
 assert_recursive_signature() {
   local layout="${1:?layout required}" count="${2:?count required}" expected="${3:?expected signature required}" setup
   setup="_mosaic_window_pane_count() { printf '%s\\n' $count; }"
@@ -204,6 +214,22 @@ distinct_pane_lefts() {
   [ "$(last_pane_id t:1)" = "$pane" ]
   [ "$(_mosaic_pane_left "$pane")" -gt 0 ]
   [ "$(_mosaic_pane_top "$pane")" -eq 0 ]
+}
+
+@test "new-pane fast paths: centered-master first left-stack transition targets the tail directly" {
+  assert_default_tail_signature centered-master 2 "split:%9"
+}
+
+@test "new-pane fast paths: centered-master later parity transitions still target the right tail directly" {
+  assert_default_tail_signature centered-master 4 "split:%9"
+}
+
+@test "new-pane fast paths: three-column first middle-column transition targets the tail directly" {
+  assert_default_tail_signature three-column 2 "split:%9"
+}
+
+@test "new-pane fast paths: three-column later parity transitions still target the right tail directly" {
+  assert_default_tail_signature three-column 3 "split:%9"
 }
 
 @test "new-pane fast paths: dwindle targets the recursive tail with the master split first" {


### PR DESCRIPTION
## Problem

`centered-master` and `three-column` still routed default `new-pane` parity transitions through the generic append path, which added extra pre-relayout churn in the `2->3`, `4->5`, and `3->4` cases from #110 and #111.

## Solution

Split the semantic tail directly for the default `nmaster=1` parity transitions in both layouts, keep the append fallback for non-default `nmaster`, and add fast-path plus acceptance coverage for the remaining role shifts. Closes #110 and #111.