### PR TITLE
feat(new-pane): reduce master-stack transition churn

### DIFF
--- a/scripts/layouts/master-stack.sh
+++ b/scripts/layouts/master-stack.sh
@@ -85,18 +85,50 @@ _layout_relayout() {
   _mosaic_log "relayout: win=$win n=$n orientation=$orientation nmaster=$nmaster mfact=$mfact"
 }
 
+_layout_new_pane_all_masters() {
+  local win="$1" orientation="$2" n="$3" pbase="$4" target pane
+  local -a flags=()
+  case "$orientation" in
+  left)
+    target=$(_mosaic_window_last_pane "$win")
+    flags=(-h)
+    ;;
+  right)
+    target="$win.$pbase"
+    flags=(-h -b)
+    ;;
+  top)
+    target=$(_mosaic_window_last_pane "$win")
+    ;;
+  bottom)
+    target="$win.$pbase"
+    flags=(-b)
+    ;;
+  esac
+  pane=$(_mosaic_new_pane_split "$target" "${flags[@]}") || return 1
+  case "$orientation" in
+  right | bottom) _mosaic_bubble_keep_focus "$pbase" "$((pbase + n))" ;;
+  esac
+  printf '%s\n' "$pane"
+}
+
 _layout_toggle() { _mosaic_toggle_window; }
 _layout_new_pane() {
-  local win n nmaster orientation target
+  local win n nmaster orientation target pbase
   local -a flags=()
   win=$(_mosaic_resolve_window "${1:-}")
   n=$(_mosaic_window_pane_count "$win")
   nmaster=$(_mosaic_effective_nmaster "$win" "$n")
-  if [[ "$n" -le "$nmaster" ]]; then
+  if [[ "$n" -lt "$nmaster" || "$nmaster" -eq 1 && "$n" -eq "$nmaster" ]]; then
     _mosaic_new_pane_append "$win"
     return
   fi
   orientation=$(_layout_orientation_for "$win")
+  if [[ "$n" -eq "$nmaster" ]]; then
+    pbase=$(_layout_pane_base)
+    _layout_new_pane_all_masters "$win" "$orientation" "$n" "$pbase"
+    return
+  fi
   target=$(_mosaic_window_last_pane "$win")
   case "$orientation" in
   top | bottom) flags=(-h) ;;

--- a/tests/integration/new_pane_acceptance.bats
+++ b/tests/integration/new_pane_acceptance.bats
@@ -19,6 +19,17 @@ setup_layout() {
   done
 }
 
+setup_master_stack_transition() {
+  local orientation="${1:?orientation required}" nmaster="${2:?nmaster required}"
+  _mosaic_use_layout master-stack
+  _mosaic_t set-option -wq -t t:1 "@mosaic-orientation" "$orientation"
+  _mosaic_t set-option -wq -t t:1 "@mosaic-nmaster" "$nmaster"
+  _mosaic_wait_option_set @mosaic-_fingerprint t:1
+  for ((i = 1; i < nmaster; i++)); do
+    _mosaic_split
+  done
+}
+
 @test "new-pane acceptance: dwindle tail growth is an exact local split" {
   local first second third tail pane
   local first_rect second_rect third_rect
@@ -59,6 +70,40 @@ setup_layout() {
   read -r new_left new_top new_width new_height <<<"$(_mosaic_pane_rect "$pane")"
   _mosaic_rect_contains "$left" "$top" "$width" "$height" "$new_left" "$new_top" "$new_width" "$new_height"
   [ "$(_mosaic_pane_width "$first")" -lt "$first_width" ]
+}
+
+@test "new-pane acceptance: master-stack left all-masters transition compresses masters into the left branch while the new pane stays right" {
+  local top_master bottom_master pane
+  local top_master_left bottom_master_left
+
+  setup_master_stack_transition left 2
+  top_master=$(_mosaic_pane_id_at t:1.1)
+  bottom_master=$(_mosaic_pane_id_at t:1.2)
+
+  pane=$(_mosaic_new_pane)
+  top_master_left=$(_mosaic_pane_left "$top_master")
+  bottom_master_left=$(_mosaic_pane_left "$bottom_master")
+
+  [ "$top_master_left" -eq 0 ]
+  [ "$bottom_master_left" -eq 0 ]
+  [ "$(_mosaic_pane_left "$pane")" -gt "$top_master_left" ]
+}
+
+@test "new-pane acceptance: master-stack right all-masters transition compresses masters into the right branch while the new pane stays left" {
+  local top_master bottom_master pane
+  local top_master_left bottom_master_left
+
+  setup_master_stack_transition right 2
+  top_master=$(_mosaic_pane_id_at t:1.1)
+  bottom_master=$(_mosaic_pane_id_at t:1.2)
+
+  pane=$(_mosaic_new_pane)
+  top_master_left=$(_mosaic_pane_left "$top_master")
+  bottom_master_left=$(_mosaic_pane_left "$bottom_master")
+
+  [ "$top_master_left" -gt 0 ]
+  [ "$bottom_master_left" -gt 0 ]
+  [ "$(_mosaic_pane_left "$pane")" -lt "$top_master_left" ]
 }
 
 @test "new-pane acceptance: centered-master two-to-three introduces the left stack while keeping the new pane on the right" {

--- a/tests/integration/new_pane_fast_paths.bats
+++ b/tests/integration/new_pane_fast_paths.bats
@@ -30,6 +30,24 @@ layout_new_pane_signature() {
   '
 }
 
+layout_new_pane_trace() {
+  local layout="${1:?layout required}" target="${2:-t:1}" setup="${3:-}" trace_file
+  trace_file=$(mktemp)
+  REPO_ROOT="$REPO_ROOT" LAYOUT="$layout" TARGET="$target" SETUP="$setup" TRACE_FILE="$trace_file" bash -lc '
+    set -euo pipefail
+    source "$REPO_ROOT/scripts/helpers.sh"
+    _mosaic_window_last_pane() { printf "%s\n" "%9"; }
+    _mosaic_new_pane_split() { printf "split:%s\n" "$*" >>"$TRACE_FILE"; printf "%s\n" "%10"; }
+    _mosaic_new_pane_append() { printf "append:%s\n" "$*" >>"$TRACE_FILE"; printf "%s\n" "%10"; }
+    _mosaic_bubble_keep_focus() { printf "bubble:%s->%s\n" "$1" "$2" >>"$TRACE_FILE"; }
+    source "$REPO_ROOT/scripts/layouts/$LAYOUT.sh"
+    eval "$SETUP"
+    _layout_new_pane "$TARGET" >/dev/null
+    cat "$TRACE_FILE"
+  '
+  rm -f "$trace_file"
+}
+
 assert_master_stack_signature() {
   local orientation="${1:?orientation required}" expected="${2:?expected signature required}" setup
   setup="_mosaic_window_pane_count() { printf '%s\\n' 3; }
@@ -37,6 +55,18 @@ _mosaic_effective_nmaster() { printf '%s\\n' 1; }
 _layout_orientation_for() { printf '%s\\n' $orientation; }"
 
   run layout_new_pane_signature master-stack t:1 "$setup"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$expected" ]
+}
+
+assert_master_stack_all_masters_trace() {
+  local orientation="${1:?orientation required}" count="${2:?count required}" expected="${3:?expected trace required}" setup
+  setup="_mosaic_window_pane_count() { printf '%s\\n' $count; }
+_mosaic_effective_nmaster() { printf '%s\\n' $count; }
+_layout_orientation_for() { printf '%s\\n' $orientation; }
+_layout_pane_base() { printf '%s\\n' 1; }"
+
+  run layout_new_pane_trace master-stack t:1 "$setup"
   [ "$status" -eq 0 ]
   [ "$output" = "$expected" ]
 }
@@ -174,6 +204,83 @@ distinct_pane_lefts() {
 
 @test "new-pane fast paths: master-stack existing bottom stack targets the tail directly" {
   assert_master_stack_signature bottom "split:%9 -h"
+}
+
+@test "new-pane fast paths: master-stack all-masters left transition splits the tail into the future stack branch" {
+  assert_master_stack_all_masters_trace left 2 "split:%9 -h"
+}
+
+@test "new-pane fast paths: master-stack all-masters top transition splits the tail into the future stack branch" {
+  assert_master_stack_all_masters_trace top 2 "split:%9"
+}
+
+@test "new-pane fast paths: master-stack all-masters right transition splits the first master and bubbles the new pane to the tail" {
+  assert_master_stack_all_masters_trace right 2 $'split:t:1.1 -h -b\nbubble:1->3'
+}
+
+@test "new-pane fast paths: master-stack all-masters bottom transition splits the first master and bubbles the new pane to the tail" {
+  assert_master_stack_all_masters_trace bottom 2 $'split:t:1.1 -b\nbubble:1->3'
+}
+
+@test "new-pane fast paths: master-stack mirrored all-masters transitions scale the bubble target with nmaster" {
+  assert_master_stack_all_masters_trace right 3 $'split:t:1.1 -h -b\nbubble:1->4'
+}
+
+@test "new-pane fast paths: master-stack all-masters left transition starts the new pane on the right before relayout" {
+  local before pane
+  _mosaic_use_layout master-stack
+  _mosaic_t set-option -wq -t t:1 "@mosaic-orientation" "left"
+  _mosaic_t set-option -wq -t t:1 "@mosaic-nmaster" "2"
+  _mosaic_wait_option_set @mosaic-_fingerprint t:1
+  _mosaic_split t:1
+  _mosaic_t select-pane -t t:1.1
+  before=$(_mosaic_pane_ids t:1)
+
+  run layout_new_pane_direct master-stack t:1
+  [ "$status" -eq 0 ]
+  pane=$(_mosaic_new_pane_id_from "$before" t:1)
+
+  _mosaic_wait_pane_present "$pane" t:1
+  [ "$(last_pane_id t:1)" = "$pane" ]
+  [ "$(_mosaic_pane_left "$pane")" -gt 0 ]
+}
+
+@test "new-pane fast paths: master-stack all-masters right transition keeps the new pane on the left and at the tail before relayout" {
+  local before pane
+  _mosaic_use_layout master-stack
+  _mosaic_t set-option -wq -t t:1 "@mosaic-orientation" "right"
+  _mosaic_t set-option -wq -t t:1 "@mosaic-nmaster" "2"
+  _mosaic_wait_option_set @mosaic-_fingerprint t:1
+  _mosaic_split t:1
+  _mosaic_t select-pane -t t:1.2
+  before=$(_mosaic_pane_ids t:1)
+
+  run layout_new_pane_direct master-stack t:1
+  [ "$status" -eq 0 ]
+  pane=$(_mosaic_new_pane_id_from "$before" t:1)
+
+  _mosaic_wait_pane_present "$pane" t:1
+  [ "$(last_pane_id t:1)" = "$pane" ]
+  [ "$(_mosaic_pane_left "$pane")" -eq 0 ]
+}
+
+@test "new-pane fast paths: master-stack all-masters bottom transition keeps the new pane on the top and at the tail before relayout" {
+  local before pane
+  _mosaic_use_layout master-stack
+  _mosaic_t set-option -wq -t t:1 "@mosaic-orientation" "bottom"
+  _mosaic_t set-option -wq -t t:1 "@mosaic-nmaster" "2"
+  _mosaic_wait_option_set @mosaic-_fingerprint t:1
+  _mosaic_split t:1
+  _mosaic_t select-pane -t t:1.2
+  before=$(_mosaic_pane_ids t:1)
+
+  run layout_new_pane_direct master-stack t:1
+  [ "$status" -eq 0 ]
+  pane=$(_mosaic_new_pane_id_from "$before" t:1)
+
+  _mosaic_wait_pane_present "$pane" t:1
+  [ "$(last_pane_id t:1)" = "$pane" ]
+  [ "$(_mosaic_pane_top "$pane")" -eq 0 ]
 }
 
 @test "new-pane fast paths: centered-master targets the first side birth with a horizontal split" {


### PR DESCRIPTION
## Problem

`master-stack` still fell back to generic append when `n = m > 1`, so the first stack pane was born by splitting a master instead of appearing in the future stack branch.

## Solution

Add an all-masters `master-stack` `new-pane` path for `n = m > 1`: split the tail directly for `left` and `top`, split the first master then bubble to the tail for mirrored `right` and `bottom`, and add fast-path plus acceptance coverage for the remaining topology change. This keeps the mirrored `1 -> 2` policy tradeoff out of scope for `#114`. Closes #112.