### PR TITLE
feat(new-pane): reduce spiral node-leaf churn

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -668,14 +668,17 @@ _mosaic_fibonacci_append_phase() {
 }
 
 _mosaic_fibonacci_new_pane() {
-  local win n split order target
+  local variant win n split order target
   local -a flags=()
+  variant=$(_mosaic_fibonacci_variant)
   win=$(_mosaic_resolve_window "${1:-}")
   n=$(_mosaic_window_pane_count "$win")
   read -r split order <<<"$(_mosaic_fibonacci_append_phase "$n")"
   if [[ "$order" != "leaf-node" ]]; then
-    _mosaic_new_pane_append "$win"
-    return
+    if [[ "$variant" != "spiral" || "$order" != "node-leaf" ]]; then
+      _mosaic_new_pane_append "$win"
+      return
+    fi
   fi
   target=$(_mosaic_window_last_pane "$win")
   case "$split" in

--- a/tests/integration/new_pane_acceptance.bats
+++ b/tests/integration/new_pane_acceptance.bats
@@ -106,6 +106,25 @@ setup_master_stack_transition() {
   [ "$(_mosaic_pane_left "$pane")" -lt "$top_master_left" ]
 }
 
+@test "new-pane acceptance: spiral four-to-five pushes the old tail inward while the new pane stays outer right" {
+  local old_inner old_tail pane
+  local old_tail_left old_tail_top
+
+  setup_layout spiral 3
+  old_inner=$(_mosaic_pane_id_at t:1.3)
+  old_tail=$(_mosaic_pane_id_at t:1.4)
+  old_tail_left=$(_mosaic_pane_left "$old_tail")
+  old_tail_top=$(_mosaic_pane_top "$old_tail")
+
+  pane=$(_mosaic_new_pane)
+
+  [ "$(_mosaic_pane_left "$old_tail")" -lt "$old_tail_left" ]
+  [ "$(_mosaic_pane_left "$old_tail")" -eq "$(_mosaic_pane_left "$old_inner")" ]
+  [ "$(_mosaic_pane_top "$old_tail")" -gt "$(_mosaic_pane_top "$old_inner")" ]
+  [ "$(_mosaic_pane_left "$pane")" -eq "$old_tail_left" ]
+  [ "$(_mosaic_pane_top "$pane")" -eq "$old_tail_top" ]
+}
+
 @test "new-pane acceptance: centered-master two-to-three introduces the left stack while keeping the new pane on the right" {
   local left old_right pane
   local old_right_left

--- a/tests/integration/new_pane_fast_paths.bats
+++ b/tests/integration/new_pane_fast_paths.bats
@@ -375,8 +375,12 @@ distinct_pane_lefts() {
   assert_recursive_signature spiral 2 "split:%9"
 }
 
-@test "new-pane fast paths: spiral leaves the first node-leaf phase on the append fallback" {
-  assert_recursive_signature spiral 3 "append:t:1"
+@test "new-pane fast paths: spiral targets the first node-leaf phase with a horizontal tail split" {
+  assert_recursive_signature spiral 3 "split:%9 -h"
+}
+
+@test "new-pane fast paths: spiral later node-leaf phases keep targeting the outer tail with a horizontal split" {
+  assert_recursive_signature spiral 6 "split:%9 -h"
 }
 
 @test "new-pane fast paths: spiral 1 -> 2 starts with the new pane on the right before relayout" {
@@ -411,4 +415,43 @@ distinct_pane_lefts() {
   [ "$(last_pane_id t:1)" = "$pane" ]
   [ "$(_mosaic_pane_left "$pane")" = "$(_mosaic_pane_left "$old_tail")" ]
   [ "$(_mosaic_pane_top "$pane")" -gt "$(_mosaic_pane_top "$old_tail")" ]
+}
+
+@test "new-pane fast paths: spiral 3 -> 4 keeps the new pane in the outer right branch before relayout" {
+  local before old_tail pane
+  _mosaic_use_layout spiral
+  _mosaic_wait_option_set @mosaic-_fingerprint t:1
+  _mosaic_split t:1
+  _mosaic_split t:1
+  old_tail=$(_mosaic_pane_id_at t:1.3)
+  before=$(_mosaic_pane_ids t:1)
+
+  run layout_new_pane_direct spiral t:1
+  [ "$status" -eq 0 ]
+  pane=$(_mosaic_new_pane_id_from "$before" t:1)
+
+  _mosaic_wait_pane_present "$pane" t:1
+  [ "$(last_pane_id t:1)" = "$pane" ]
+  [ "$(_mosaic_pane_left "$pane")" -gt "$(_mosaic_pane_left "$old_tail")" ]
+  [ "$(_mosaic_pane_top "$pane")" = "$(_mosaic_pane_top "$old_tail")" ]
+}
+
+@test "new-pane fast paths: spiral 4 -> 5 keeps the new pane in the outer right branch before relayout" {
+  local before old_tail pane
+  _mosaic_use_layout spiral
+  _mosaic_wait_option_set @mosaic-_fingerprint t:1
+  _mosaic_split t:1
+  _mosaic_split t:1
+  _mosaic_split t:1
+  old_tail=$(_mosaic_pane_id_at t:1.4)
+  before=$(_mosaic_pane_ids t:1)
+
+  run layout_new_pane_direct spiral t:1
+  [ "$status" -eq 0 ]
+  pane=$(_mosaic_new_pane_id_from "$before" t:1)
+
+  _mosaic_wait_pane_present "$pane" t:1
+  [ "$(last_pane_id t:1)" = "$pane" ]
+  [ "$(_mosaic_pane_left "$pane")" -gt "$(_mosaic_pane_left "$old_tail")" ]
+  [ "$(_mosaic_pane_top "$pane")" = "$(_mosaic_pane_top "$old_tail")" ]
 }


### PR DESCRIPTION
## Problem

`spiral` still left the harder node-leaf `new-pane` phases on the generic append path, so the new pane first appeared below the tail and only reached the correct outer branch after the final relayout.

## Solution

Treat `spiral` node-leaf phases as their own fast path by splitting the tail horizontally into the outer right branch instead of using generic append, and add fast-path plus acceptance coverage for the remaining inward role shift of the previous tail. Closes #113.