### PR TITLE
feat(new-pane): finish visual-stability followups

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,52 @@ bind p select-pane -t :.-
 </details>
 
 
+## Explicit `new-pane` limits
+
+Mosaic now tries to birth explicit `new-pane` directly into the active layout's
+semantic tail before the final relayout. Most common cases stay local, but a
+few layout states still need visible correction during creation:
+
+- `master-stack`
+  - `left` and `top` `1 -> 2` start in the final broad branch immediately.
+  - `right` and `bottom` `1 -> 2` keep append-to-end pane order, so tmux can
+    only start on the non-mirrored side before the final relayout.
+  - The `nmaster > 1` all-masters -> first-stack transition still reshapes the
+    whole master block.
+- `centered-master`
+  - The first side-stack birth is targeted directly.
+  - The default `2 -> 3` transition and later odd side-stack parity changes
+    still shift one existing pane into or across the side stacks before the
+    centered layout settles.
+- `three-column`
+  - The first side-column birth is targeted directly.
+  - The default `3 -> 4` transition and later even parity changes still move
+    one existing pane from the right column into the middle column.
+- `even-horizontal` / `even-vertical`
+  - The new pane is born in the right row or column, then tmux re-equalizes the
+    whole row or column.
+- `grid`
+  - `2 -> 3` still moves the old bottom full-width pane into the new top row.
+  - Current pane counts `4`, `6`, `9`, `12`, and more generally `k^2` and
+    `k(k + 1)` for `k >= 2`, still force a true global retile on the next pane.
+  - Other tested counts now split the tail directly before the final retile.
+- `spiral`
+  - The easy leaf-node phases and the first node-leaf phase now birth in the
+    outer recursive tail directly.
+  - Later node-leaf phases still push the previous tail inward while the new
+    pane stays on the outer branch first.
+- `dwindle`
+  - Normal growth stays local to the recursive tail.
+- `monocle`
+  - `new-pane` always ends with the new pane focused and zoomed.
+  - If the window was manually unzoomed first, Mosaic reasserts zoom after
+    creation.
+- Small windows
+  - If the intended target pane is too small to split, Mosaic now falls back to
+    a generic append path when some other pane in the window can still split.
+  - If no pane in the window can split, tmux still reports `no space for new
+    pane`.
+
 ## Pane Ownership Model
 
 Once a tmux window can contain both panes that should participate in a Mosaic

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -478,14 +478,46 @@ _mosaic_new_pane_split() {
 _mosaic_new_pane_default() { _mosaic_new_pane_split "$(_mosaic_current_pane)"; }
 
 _mosaic_new_pane_append() {
-  local win="$1" pane target_pane last_pane
-  target_pane=$(_mosaic_current_pane)
+  local win="$1" pane current_pane source_pane last_pane candidate idx pbase n end
+  current_pane=$(_mosaic_current_pane)
+  source_pane="$current_pane"
   last_pane=$(_mosaic_window_last_pane "$win")
-  pane=$(_mosaic_new_pane_default) || return 1
-  if [[ "$target_pane" != "$last_pane" ]]; then
-    _mosaic_move_keep_focus -s "$pane" -t "$last_pane"
+  pane=$(_mosaic_new_pane_split "$source_pane" 2>/dev/null) || {
+    while IFS= read -r candidate; do
+      [[ -n "$candidate" ]] || continue
+      [[ "$candidate" == "$current_pane" ]] && continue
+      pane=$(_mosaic_new_pane_split "$candidate" 2>/dev/null) || continue
+      source_pane="$candidate"
+      break
+    done < <(_mosaic_window_panes "$win")
+  }
+  if [[ -z "$pane" ]]; then
+    _mosaic_new_pane_split "$current_pane"
+    return 1
+  fi
+  if [[ "$source_pane" != "$last_pane" ]]; then
+    idx=$(tmux display-message -p -t "$pane" '#{pane_index}')
+    pbase=$(_mosaic_current_pane_base)
+    n=$(_mosaic_window_pane_count "$win")
+    end=$((pbase + n - 1))
+    if [[ "$idx" -ne "$end" ]]; then
+      _mosaic_bubble_keep_focus "$idx" "$end"
+    fi
   fi
   printf '%s\n' "$pane"
+}
+
+_mosaic_new_pane_split_or_append() {
+  local win target pane
+  win=$(_mosaic_resolve_window "${1:-}")
+  target="${2:?target pane required}"
+  shift 2
+  pane=$(_mosaic_new_pane_split "$target" "$@" 2>/dev/null) && {
+    printf '%s\n' "$pane"
+    return 0
+  }
+  _mosaic_log "new-pane: fallback-append win=$win target=$target flags=$*"
+  _mosaic_new_pane_append "$win"
 }
 
 _mosaic_can_relayout_window() {
@@ -684,7 +716,7 @@ _mosaic_fibonacci_new_pane() {
   case "$split" in
   master | x) flags=(-h) ;;
   esac
-  _mosaic_new_pane_split "$target" "${flags[@]}"
+  _mosaic_new_pane_split_or_append "$win" "$target" "${flags[@]}"
 }
 
 _mosaic_fibonacci_layout_node() {

--- a/scripts/layouts/centered-master.sh
+++ b/scripts/layouts/centered-master.sh
@@ -177,7 +177,7 @@ _layout_new_pane() {
   fi
   target=$(_mosaic_window_last_pane "$win")
   [[ "$n" -eq 1 ]] && flags=(-h)
-  _mosaic_new_pane_split "$target" "${flags[@]}"
+  _mosaic_new_pane_split_or_append "$win" "$target" "${flags[@]}"
 }
 
 _layout_promote() {

--- a/scripts/layouts/even-horizontal.sh
+++ b/scripts/layouts/even-horizontal.sh
@@ -4,5 +4,5 @@ _layout_relayout() { _mosaic_relayout_simple even-horizontal "${1:-}"; }
 
 _layout_toggle() { _mosaic_toggle_window; }
 _layout_new_pane() {
-  _mosaic_new_pane_split "$(_mosaic_window_last_pane "${1:-}")" -h
+  _mosaic_new_pane_split_or_append "${1:-}" "$(_mosaic_window_last_pane "${1:-}")" -h
 }

--- a/scripts/layouts/even-vertical.sh
+++ b/scripts/layouts/even-vertical.sh
@@ -4,5 +4,5 @@ _layout_relayout() { _mosaic_relayout_simple even-vertical "${1:-}"; }
 
 _layout_toggle() { _mosaic_toggle_window; }
 _layout_new_pane() {
-  _mosaic_new_pane_split "$(_mosaic_window_last_pane "${1:-}")"
+  _mosaic_new_pane_split_or_append "${1:-}" "$(_mosaic_window_last_pane "${1:-}")"
 }

--- a/scripts/layouts/grid.sh
+++ b/scripts/layouts/grid.sh
@@ -2,5 +2,26 @@
 
 _layout_relayout() { _mosaic_relayout_simple tiled "${1:-}"; }
 
+_layout_global_reshape_count() {
+  local n="$1" k
+  [[ "$n" -ge 4 ]] || return 1
+  for ((k = 2; k * k <= n; k++)); do
+    if [[ "$n" -eq $((k * k)) || "$n" -eq $((k * (k + 1))) ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 _layout_toggle() { _mosaic_toggle_window; }
-_layout_new_pane() { _mosaic_new_pane_append "$1"; }
+_layout_new_pane() {
+  local win n target
+  win=$(_mosaic_resolve_window "${1:-}")
+  n=$(_mosaic_window_pane_count "$win")
+  target=$(_mosaic_window_last_pane "$win")
+  if [[ "$n" -eq 1 || "$n" -eq 2 ]] || _layout_global_reshape_count "$n"; then
+    _mosaic_new_pane_split_or_append "$win" "$target"
+    return
+  fi
+  _mosaic_new_pane_split_or_append "$win" "$target" -h
+}

--- a/scripts/layouts/master-stack.sh
+++ b/scripts/layouts/master-stack.sh
@@ -65,6 +65,16 @@ _layout_join_extra_masters() {
   [[ $((n - nmaster)) -gt 1 ]] && tmux select-layout -t "$win.$((pbase + nmaster))" -E 2>/dev/null || true
 }
 
+_layout_new_pane_first_stack() {
+  local win="$1" orientation="$2" target
+  local -a flags=()
+  target=$(_mosaic_window_last_pane "$win")
+  case "$orientation" in
+  left | right) flags=(-h) ;;
+  esac
+  _mosaic_new_pane_split_or_append "$win" "$target" "${flags[@]}"
+}
+
 _layout_relayout() {
   local win n mfact orientation nmaster pbase
   win=$(_mosaic_resolve_window "${1:-}")
@@ -105,9 +115,13 @@ _layout_new_pane_all_masters() {
     flags=(-b)
     ;;
   esac
-  pane=$(_mosaic_new_pane_split "$target" "${flags[@]}") || return 1
+  pane=$(_mosaic_new_pane_split_or_append "$win" "$target" "${flags[@]}") || return 1
   case "$orientation" in
-  right | bottom) _mosaic_bubble_keep_focus "$pbase" "$((pbase + n))" ;;
+  right | bottom)
+    if [[ "$pane" != "$(_mosaic_window_last_pane "$win")" ]]; then
+      _mosaic_bubble_keep_focus "$pbase" "$((pbase + n))"
+    fi
+    ;;
   esac
   printf '%s\n' "$pane"
 }
@@ -119,7 +133,12 @@ _layout_new_pane() {
   win=$(_mosaic_resolve_window "${1:-}")
   n=$(_mosaic_window_pane_count "$win")
   nmaster=$(_mosaic_effective_nmaster "$win" "$n")
-  if [[ "$n" -lt "$nmaster" || "$nmaster" -eq 1 && "$n" -eq "$nmaster" ]]; then
+  if [[ "$nmaster" -eq 1 && "$n" -eq 1 ]]; then
+    orientation=$(_layout_orientation_for "$win")
+    _layout_new_pane_first_stack "$win" "$orientation"
+    return
+  fi
+  if [[ "$n" -lt "$nmaster" ]]; then
     _mosaic_new_pane_append "$win"
     return
   fi
@@ -133,7 +152,7 @@ _layout_new_pane() {
   case "$orientation" in
   top | bottom) flags=(-h) ;;
   esac
-  _mosaic_new_pane_split "$target" "${flags[@]}"
+  _mosaic_new_pane_split_or_append "$win" "$target" "${flags[@]}"
 }
 
 _layout_promote() {

--- a/scripts/layouts/three-column.sh
+++ b/scripts/layouts/three-column.sh
@@ -150,7 +150,7 @@ _layout_new_pane() {
   fi
   target=$(_mosaic_window_last_pane "$win")
   [[ "$n" -eq 1 ]] && flags=(-h)
-  _mosaic_new_pane_split "$target" "${flags[@]}"
+  _mosaic_new_pane_split_or_append "$win" "$target" "${flags[@]}"
 }
 
 _layout_promote() {

--- a/tests/integration/grid.bats
+++ b/tests/integration/grid.bats
@@ -11,6 +11,11 @@ teardown() {
   _mosaic_teardown_server
 }
 
+grid_helper_eval() {
+  local cmd="${1:?command required}"
+  REPO_ROOT="$REPO_ROOT" bash -lc "source '$REPO_ROOT/scripts/helpers.sh'; source '$REPO_ROOT/scripts/layouts/grid.sh'; $cmd"
+}
+
 @test "grid: 4 panes use tiled layout" {
   for _ in 1 2 3; do _mosaic_split; done
   _mosaic_op relayout
@@ -29,6 +34,18 @@ teardown() {
   [ "$(printf '%s\n' "$tops" | wc -l)" = "2" ]
   [ $(($(printf '%s\n' "$widths" | tail -n1) - $(printf '%s\n' "$widths" | head -n1))) -le 1 ]
   [ $(($(printf '%s\n' "$heights" | tail -n1) - $(printf '%s\n' "$heights" | head -n1))) -le 1 ]
+}
+
+@test "grid: global reshape counts follow the square and square-plus-row families" {
+  run grid_helper_eval '
+    for n in 3 4 5 6 7 8 9 10 11 12; do
+      if _layout_global_reshape_count "$n"; then
+        printf "%s\n" "$n"
+      fi
+    done
+  '
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(printf '4\n6\n9\n12')" ]
 }
 
 @test "grid: promote surfaces the missing operation message in direct cli use" {

--- a/tests/integration/monocle.bats
+++ b/tests/integration/monocle.bats
@@ -40,6 +40,19 @@ active_pane_id() {
   [ "$(_mosaic_pane_index)" = "2" ]
 }
 
+@test "monocle: explicit new-pane re-zooms and focuses the new pane after manual unzoom" {
+  local pane
+  for _ in 1 2; do _mosaic_split; done
+
+  _mosaic_t resize-pane -Z -t t:1
+  [ "$(window_zoomed)" = "0" ]
+
+  pane=$(_mosaic_new_pane)
+
+  [ "$(window_zoomed)" = "1" ]
+  [ "$(active_pane_id)" = "$pane" ]
+}
+
 @test "monocle: selecting the next pane re-zooms the new active pane" {
   for _ in 1 2; do _mosaic_split; done
 

--- a/tests/integration/new_pane_acceptance.bats
+++ b/tests/integration/new_pane_acceptance.bats
@@ -176,6 +176,23 @@ setup_master_stack_transition() {
   [ "$(_mosaic_pane_left "$pane")" -gt "$(_mosaic_pane_left "$old_right")" ]
 }
 
+@test "new-pane acceptance: grid two-to-three moves the old bottom pane into the top row while the new pane stays on the bottom" {
+  local old_top old_bottom pane
+  local old_bottom_top
+
+  setup_layout grid 1
+  old_top=$(_mosaic_pane_id_at t:1.1)
+  old_bottom=$(_mosaic_pane_id_at t:1.2)
+  old_bottom_top=$(_mosaic_pane_top "$old_bottom")
+
+  pane=$(_mosaic_new_pane)
+
+  [ "$(_mosaic_pane_top "$old_top")" -eq 0 ]
+  [ "$(_mosaic_pane_top "$old_bottom")" -lt "$old_bottom_top" ]
+  [ "$(_mosaic_pane_top "$old_bottom")" -eq "$(_mosaic_pane_top "$old_top")" ]
+  [ "$(_mosaic_pane_top "$pane")" -gt "$(_mosaic_pane_top "$old_top")" ]
+}
+
 @test "new-pane acceptance: grid four-to-five is a global reshape" {
   local first second third fourth pane
   local first_rect second_rect third_rect fourth_rect
@@ -198,6 +215,25 @@ setup_master_stack_transition() {
   ! _mosaic_rect_contains $second_rect "$new_left" "$new_top" "$new_width" "$new_height"
   ! _mosaic_rect_contains $third_rect "$new_left" "$new_top" "$new_width" "$new_height"
   ! _mosaic_rect_contains $fourth_rect "$new_left" "$new_top" "$new_width" "$new_height"
+}
+
+@test "new-pane acceptance: grid six-to-seven is also a global reshape" {
+  local pane
+  local new_left new_top new_width new_height
+  local -a rects
+
+  setup_layout grid 5
+  while IFS= read -r old; do
+    [[ -n "$old" ]] || continue
+    rects+=("$(_mosaic_pane_rect "$old")")
+  done < <(_mosaic_pane_ids t:1)
+
+  pane=$(_mosaic_new_pane)
+  read -r new_left new_top new_width new_height <<<"$(_mosaic_pane_rect "$pane")"
+
+  for rect in "${rects[@]}"; do
+    ! _mosaic_rect_contains $rect "$new_left" "$new_top" "$new_width" "$new_height"
+  done
 }
 
 @test "new-pane acceptance: tmux cannot get mirrored side and append order from one horizontal split" {
@@ -231,6 +267,44 @@ setup_master_stack_transition() {
   [ "$(_mosaic_t display-message -p -t t:1 '#{window_zoomed_flag}')" = "1" ]
   [ "$(_mosaic_t display-message -p -t t:1 '#{pane_id}')" = "$pane" ]
   [ "$pane" != "$active_before" ]
+}
+
+@test "new-pane acceptance: master-stack falls back when the stack tail is too small" {
+  local tail pane
+
+  _mosaic_teardown_server
+  _mosaic_setup_server 20 10
+  _mosaic_use_layout master-stack
+  _mosaic_wait_option_set @mosaic-_fingerprint t:1
+  for _ in 1 2 3; do
+    _mosaic_split
+  done
+  tail=$(_mosaic_pane_id_at t:1.4)
+  _mosaic_t select-pane -t "$tail"
+
+  pane=$(_mosaic_new_pane)
+
+  [ "$(_mosaic_pane_count t:1)" = "5" ]
+  [ "$(_mosaic_last_pane_id t:1)" = "$pane" ]
+}
+
+@test "new-pane acceptance: centered-master falls back when the side tail is too small" {
+  local tail pane
+
+  _mosaic_teardown_server
+  _mosaic_setup_server 20 10
+  _mosaic_use_layout centered-master
+  _mosaic_wait_option_set @mosaic-_fingerprint t:1
+  for _ in 1 2 3 4 5; do
+    _mosaic_split
+  done
+  tail=$(_mosaic_pane_id_at t:1.6)
+  _mosaic_t select-pane -t "$tail"
+
+  pane=$(_mosaic_new_pane)
+
+  [ "$(_mosaic_pane_count t:1)" = "7" ]
+  [ "$(_mosaic_last_pane_id t:1)" = "$pane" ]
 }
 
 @test "new-pane acceptance: raw split reports no space on a tiny pane" {

--- a/tests/integration/new_pane_fast_paths.bats
+++ b/tests/integration/new_pane_fast_paths.bats
@@ -71,6 +71,17 @@ _layout_pane_base() { printf '%s\\n' 1; }"
   [ "$output" = "$expected" ]
 }
 
+assert_master_stack_first_stack_signature() {
+  local orientation="${1:?orientation required}" expected="${2:?expected signature required}" setup
+  setup="_mosaic_window_pane_count() { printf '%s\\n' 1; }
+_mosaic_effective_nmaster() { printf '%s\\n' 1; }
+_layout_orientation_for() { printf '%s\\n' $orientation; }"
+
+  run layout_new_pane_signature master-stack t:1 "$setup"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$expected" ]
+}
+
 assert_single_side_signature() {
   local layout="${1:?layout required}" expected="${2:?expected signature required}" setup
   setup="_mosaic_window_pane_count() { printf '%s\\n' 1; }
@@ -91,9 +102,29 @@ _mosaic_nmaster_for() { printf '%s\\n' 1; }"
   [ "$output" = "$expected" ]
 }
 
+assert_grid_signature() {
+  local count="${1:?count required}" expected="${2:?expected signature required}" setup
+  setup="_mosaic_window_pane_count() { printf '%s\\n' $count; }"
+
+  run layout_new_pane_signature grid t:1 "$setup"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$expected" ]
+}
+
 assert_recursive_signature() {
   local layout="${1:?layout required}" count="${2:?count required}" expected="${3:?expected signature required}" setup
   setup="_mosaic_window_pane_count() { printf '%s\\n' $count; }"
+
+  run layout_new_pane_signature "$layout" t:1 "$setup"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$expected" ]
+}
+
+assert_split_failure_falls_back() {
+  local layout="${1:?layout required}" count="${2:?count required}" expected="${3:?expected signature required}" setup
+  setup="_mosaic_window_pane_count() { printf '%s\\n' $count; }
+_mosaic_new_pane_split() { return 1; }
+_mosaic_new_pane_append() { printf '$expected\\n'; }"
 
   run layout_new_pane_signature "$layout" t:1 "$setup"
   [ "$status" -eq 0 ]
@@ -190,8 +221,108 @@ distinct_pane_lefts() {
   [ "$(distinct_pane_lefts t:1)" = "0" ]
 }
 
+@test "new-pane fast paths: grid 1 -> 2 keeps the default split on the tail" {
+  assert_grid_signature 1 "split:%9"
+}
+
+@test "new-pane fast paths: grid 2 -> 3 keeps the default split on the tail" {
+  assert_grid_signature 2 "split:%9"
+}
+
+@test "new-pane fast paths: grid 3 -> 4 targets the tail with a horizontal split" {
+  assert_grid_signature 3 "split:%9 -h"
+}
+
+@test "new-pane fast paths: grid 4 -> 5 keeps the default split for an unavoidable global reshape" {
+  assert_grid_signature 4 "split:%9"
+}
+
+@test "new-pane fast paths: grid 5 -> 6 targets the tail with a horizontal split" {
+  assert_grid_signature 5 "split:%9 -h"
+}
+
+@test "new-pane fast paths: grid 6 -> 7 keeps the default split for an unavoidable global reshape" {
+  assert_grid_signature 6 "split:%9"
+}
+
+@test "new-pane fast paths: grid 2 -> 3 keeps the new pane in the bottom tail before relayout" {
+  local before old_tail pane
+  _mosaic_use_layout grid
+  _mosaic_wait_option_set @mosaic-_fingerprint t:1
+  _mosaic_split t:1
+  _mosaic_t select-pane -t t:1.1
+  old_tail=$(_mosaic_pane_id_at t:1.2)
+  before=$(_mosaic_pane_ids t:1)
+
+  run layout_new_pane_direct grid t:1
+  [ "$status" -eq 0 ]
+  pane=$(_mosaic_new_pane_id_from "$before" t:1)
+
+  _mosaic_wait_pane_present "$pane" t:1
+  [ "$(last_pane_id t:1)" = "$pane" ]
+  [ "$(_mosaic_pane_left "$pane")" = "$(_mosaic_pane_left "$old_tail")" ]
+  [ "$(_mosaic_pane_top "$pane")" -gt "$(_mosaic_pane_top "$old_tail")" ]
+}
+
+@test "new-pane fast paths: grid 3 -> 4 splits the bottom tail to the right before relayout" {
+  local before old_tail pane
+  _mosaic_use_layout grid
+  _mosaic_wait_option_set @mosaic-_fingerprint t:1
+  _mosaic_split t:1
+  _mosaic_split t:1
+  _mosaic_t select-pane -t t:1.1
+  old_tail=$(_mosaic_pane_id_at t:1.3)
+  before=$(_mosaic_pane_ids t:1)
+
+  run layout_new_pane_direct grid t:1
+  [ "$status" -eq 0 ]
+  pane=$(_mosaic_new_pane_id_from "$before" t:1)
+
+  _mosaic_wait_pane_present "$pane" t:1
+  [ "$(last_pane_id t:1)" = "$pane" ]
+  [ "$(_mosaic_pane_left "$pane")" -gt "$(_mosaic_pane_left "$old_tail")" ]
+  [ "$(_mosaic_pane_top "$pane")" = "$(_mosaic_pane_top "$old_tail")" ]
+}
+
+@test "new-pane fast paths: grid 4 -> 5 keeps the new pane in the tail pane's lower band before relayout" {
+  local before old_tail pane
+  _mosaic_use_layout grid
+  _mosaic_wait_option_set @mosaic-_fingerprint t:1
+  _mosaic_split t:1
+  _mosaic_split t:1
+  _mosaic_split t:1
+  _mosaic_t select-pane -t t:1.1
+  old_tail=$(_mosaic_pane_id_at t:1.4)
+  before=$(_mosaic_pane_ids t:1)
+
+  run layout_new_pane_direct grid t:1
+  [ "$status" -eq 0 ]
+  pane=$(_mosaic_new_pane_id_from "$before" t:1)
+
+  _mosaic_wait_pane_present "$pane" t:1
+  [ "$(last_pane_id t:1)" = "$pane" ]
+  [ "$(_mosaic_pane_left "$pane")" = "$(_mosaic_pane_left "$old_tail")" ]
+  [ "$(_mosaic_pane_top "$pane")" -gt "$(_mosaic_pane_top "$old_tail")" ]
+}
+
 @test "new-pane fast paths: master-stack existing left stack targets the tail directly" {
   assert_master_stack_signature left "split:%9"
+}
+
+@test "new-pane fast paths: master-stack first left stack pane uses a horizontal split" {
+  assert_master_stack_first_stack_signature left "split:%9 -h"
+}
+
+@test "new-pane fast paths: master-stack first top stack pane keeps the default split" {
+  assert_master_stack_first_stack_signature top "split:%9"
+}
+
+@test "new-pane fast paths: master-stack first right stack pane preserves append order with a horizontal split" {
+  assert_master_stack_first_stack_signature right "split:%9 -h"
+}
+
+@test "new-pane fast paths: master-stack first bottom stack pane preserves append order with the default split" {
+  assert_master_stack_first_stack_signature bottom "split:%9"
 }
 
 @test "new-pane fast paths: master-stack existing right stack targets the tail directly" {
@@ -243,6 +374,74 @@ distinct_pane_lefts() {
   _mosaic_wait_pane_present "$pane" t:1
   [ "$(last_pane_id t:1)" = "$pane" ]
   [ "$(_mosaic_pane_left "$pane")" -gt 0 ]
+}
+
+@test "new-pane fast paths: master-stack left 1 -> 2 starts the new pane on the right before relayout" {
+  local before pane
+  _mosaic_use_layout master-stack
+  _mosaic_t set-option -wq -t t:1 "@mosaic-orientation" "left"
+  _mosaic_wait_option_set @mosaic-_fingerprint t:1
+  before=$(_mosaic_pane_ids t:1)
+
+  run layout_new_pane_direct master-stack t:1
+  [ "$status" -eq 0 ]
+  pane=$(_mosaic_new_pane_id_from "$before" t:1)
+
+  _mosaic_wait_pane_present "$pane" t:1
+  [ "$(last_pane_id t:1)" = "$pane" ]
+  [ "$(_mosaic_pane_left "$pane")" -gt 0 ]
+  [ "$(_mosaic_pane_top "$pane")" -eq 0 ]
+}
+
+@test "new-pane fast paths: master-stack top 1 -> 2 starts the new pane at the bottom before relayout" {
+  local before pane
+  _mosaic_use_layout master-stack
+  _mosaic_t set-option -wq -t t:1 "@mosaic-orientation" "top"
+  _mosaic_wait_option_set @mosaic-_fingerprint t:1
+  before=$(_mosaic_pane_ids t:1)
+
+  run layout_new_pane_direct master-stack t:1
+  [ "$status" -eq 0 ]
+  pane=$(_mosaic_new_pane_id_from "$before" t:1)
+
+  _mosaic_wait_pane_present "$pane" t:1
+  [ "$(last_pane_id t:1)" = "$pane" ]
+  [ "$(_mosaic_pane_left "$pane")" -eq 0 ]
+  [ "$(_mosaic_pane_top "$pane")" -gt 0 ]
+}
+
+@test "new-pane fast paths: master-stack right 1 -> 2 keeps the new pane at the tail and in a side split before relayout" {
+  local before pane
+  _mosaic_use_layout master-stack
+  _mosaic_t set-option -wq -t t:1 "@mosaic-orientation" "right"
+  _mosaic_wait_option_set @mosaic-_fingerprint t:1
+  before=$(_mosaic_pane_ids t:1)
+
+  run layout_new_pane_direct master-stack t:1
+  [ "$status" -eq 0 ]
+  pane=$(_mosaic_new_pane_id_from "$before" t:1)
+
+  _mosaic_wait_pane_present "$pane" t:1
+  [ "$(last_pane_id t:1)" = "$pane" ]
+  [ "$(_mosaic_pane_left "$pane")" -gt 0 ]
+  [ "$(_mosaic_pane_top "$pane")" -eq 0 ]
+}
+
+@test "new-pane fast paths: master-stack bottom 1 -> 2 keeps the new pane at the tail and in a bottom split before relayout" {
+  local before pane
+  _mosaic_use_layout master-stack
+  _mosaic_t set-option -wq -t t:1 "@mosaic-orientation" "bottom"
+  _mosaic_wait_option_set @mosaic-_fingerprint t:1
+  before=$(_mosaic_pane_ids t:1)
+
+  run layout_new_pane_direct master-stack t:1
+  [ "$status" -eq 0 ]
+  pane=$(_mosaic_new_pane_id_from "$before" t:1)
+
+  _mosaic_wait_pane_present "$pane" t:1
+  [ "$(last_pane_id t:1)" = "$pane" ]
+  [ "$(_mosaic_pane_left "$pane")" -eq 0 ]
+  [ "$(_mosaic_pane_top "$pane")" -gt 0 ]
 }
 
 @test "new-pane fast paths: master-stack all-masters right transition keeps the new pane on the left and at the tail before relayout" {
@@ -351,6 +550,10 @@ distinct_pane_lefts() {
   assert_recursive_signature dwindle 3 "split:%9 -h"
 }
 
+@test "new-pane fast paths: dwindle falls back to append when the recursive tail split fails" {
+  assert_split_failure_falls_back dwindle 3 "append:t:1"
+}
+
 @test "new-pane fast paths: dwindle 1 -> 2 starts with the new pane on the right before relayout" {
   local before pane
   _mosaic_use_layout dwindle
@@ -377,6 +580,10 @@ distinct_pane_lefts() {
 
 @test "new-pane fast paths: spiral targets the first node-leaf phase with a horizontal tail split" {
   assert_recursive_signature spiral 3 "split:%9 -h"
+}
+
+@test "new-pane fast paths: spiral falls back to append when the recursive tail split fails" {
+  assert_split_failure_falls_back spiral 3 "append:t:1"
 }
 
 @test "new-pane fast paths: spiral later node-leaf phases keep targeting the outer tail with a horizontal split" {


### PR DESCRIPTION
## Problem

The remaining explicit managed `new-pane` follow-up issues still left unresolved policy and fallback behavior across `master-stack`, `grid`, `monocle`, and small-window cases, and the residual limits were not documented.

## Solution

Finish the remaining layout-specific `new-pane` policies, add shared split-or-append fallback behavior and integration coverage for the hard cases, and document the residual creation-time limits in the README.
