### PR TITLE
fix(release): make nightlies immutable per commit

### DIFF
--- a/.github/RELEASE_PROCESS.md
+++ b/.github/RELEASE_PROCESS.md
@@ -95,7 +95,8 @@ Confirm all of the following:
 ## Nightly prereleases
 
 While `main` carries a dev version, the `Nightly Release` workflow can publish a
-moving `nightly` prerelease from the latest successful `quality` run on `main`.
+per-commit nightly prerelease from the latest successful `quality` run on
+`main`, while also refreshing a moving `nightly` alias.
 
 You can trigger it manually with:
 
@@ -106,9 +107,13 @@ gh workflow run release_nightly.yaml --repo barrettruth/tmux-mosaic
 The nightly workflow:
 
 - only publishes when the current version is a dev version
-- deletes and recreates the `nightly` tag if the target commit changed
+- creates an immutable nightly tag and prerelease named
+  `nightly-<version>-<shortsha>` for the target commit
+- refreshes the moving `nightly` tag and prerelease to point at that same
+  commit
 - generates notes against the latest stable tag when one exists
-- creates the `nightly` GitHub Release as a prerelease and marks it non-latest
+- marks nightly prereleases non-latest so stable releases keep the repo's
+  canonical latest slot
 
 ## Release notes
 

--- a/.github/workflows/release_nightly.yaml
+++ b/.github/workflows/release_nightly.yaml
@@ -41,27 +41,46 @@ jobs:
       - name: Resolve nightly state
         id: state
         run: |
+          remote_tag_target() {
+            local tag="$1" target
+            target="$(git ls-remote --tags origin "refs/tags/$tag^{}" | awk '{print $1}')"
+            if [ -z "$target" ]; then
+              target="$(git ls-remote --tags origin "refs/tags/$tag" | awk '{print $1}')"
+            fi
+            printf '%s\n' "$target"
+          }
           git fetch --tags origin
+          head_sha="${{ steps.run.outputs.head_sha }}"
           version="$(scripts/release-version.sh get)"
           if ! scripts/release-version.sh assert-dev "$version" >/dev/null 2>&1; then
             echo "publish=false" >>"$GITHUB_OUTPUT"
             exit 0
           fi
-          short_sha="${{ steps.run.outputs.head_sha }}"
-          short_sha="${short_sha:0:7}"
+          nightly_tag="$(scripts/release-version.sh nightly-tag "$version" "$head_sha")"
+          short_sha="${head_sha:0:7}"
           title="Nightly $version ($short_sha)"
           previous_tag="$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n 1 || true)"
-          current="$(git ls-remote --tags origin 'refs/tags/nightly^{}' | awk '{print $1}')"
-          if [ -z "$current" ]; then
-            current="$(git ls-remote --tags origin 'refs/tags/nightly' | awk '{print $1}')"
+          immutable_current="$(remote_tag_target "$nightly_tag")"
+          alias_current="$(remote_tag_target nightly)"
+          immutable_release_exists=false
+          if gh release view "$nightly_tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            immutable_release_exists=true
           fi
-          if [ "$current" = "${{ steps.run.outputs.head_sha }}" ]; then
+          alias_release_exists=false
+          if gh release view nightly --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            alias_release_exists=true
+          fi
+          if [ "$immutable_current" = "$head_sha" ] &&
+            [ "$alias_current" = "$head_sha" ] &&
+            [ "$immutable_release_exists" = true ] &&
+            [ "$alias_release_exists" = true ]; then
             echo "publish=false" >>"$GITHUB_OUTPUT"
             exit 0
           fi
           {
             echo "publish=true"
             echo "version=$version"
+            echo "nightly_tag=$nightly_tag"
             echo "previous_tag=$previous_tag"
             echo "title=$title"
           } >>"$GITHUB_OUTPUT"
@@ -70,23 +89,52 @@ jobs:
         run: |
           if [ -n "${{ steps.state.outputs.previous_tag }}" ]; then
             gh api -X POST "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
-              -f tag_name=nightly \
+              -f tag_name="${{ steps.state.outputs.nightly_tag }}" \
               -f target_commitish="${{ steps.run.outputs.head_sha }}" \
               -f previous_tag_name="${{ steps.state.outputs.previous_tag }}" >"$RUNNER_TEMP/nightly-notes.json"
           else
             gh api -X POST "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
-              -f tag_name=nightly \
+              -f tag_name="${{ steps.state.outputs.nightly_tag }}" \
               -f target_commitish="${{ steps.run.outputs.head_sha }}" >"$RUNNER_TEMP/nightly-notes.json"
           fi
-          printf "Built from \`%s\`.\n\n" "${{ steps.run.outputs.head_sha }}" >"$RUNNER_TEMP/nightly-notes.md"
+          printf "Built from \`%s\`.\nImmutable tag: \`%s\`.\n\n" "${{ steps.run.outputs.head_sha }}" "${{ steps.state.outputs.nightly_tag }}" >"$RUNNER_TEMP/nightly-notes.md"
           jq -r '.body' "$RUNNER_TEMP/nightly-notes.json" >>"$RUNNER_TEMP/nightly-notes.md"
-      - name: Create or update nightly release
+          printf "Alias for \`%s\`, built from \`%s\`.\n\n" "${{ steps.state.outputs.nightly_tag }}" "${{ steps.run.outputs.head_sha }}" >"$RUNNER_TEMP/nightly-alias-notes.md"
+          jq -r '.body' "$RUNNER_TEMP/nightly-notes.json" >>"$RUNNER_TEMP/nightly-alias-notes.md"
+      - name: Create or update immutable nightly release
+        if: steps.state.outputs.publish == 'true'
+        run: |
+          tag="${{ steps.state.outputs.nightly_tag }}"
+          if ! git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
+            git tag -d "$tag" >/dev/null 2>&1 || true
+            GIT_COMMITTER_NAME='github-actions[bot]' \
+            GIT_COMMITTER_EMAIL='41898282+github-actions[bot]@users.noreply.github.com' \
+            git tag -a "$tag" "${{ steps.run.outputs.head_sha }}" -m "$tag"
+            git push origin "refs/tags/$tag"
+          fi
+          if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release edit "$tag" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "${{ steps.state.outputs.title }}" \
+              --notes-file "$RUNNER_TEMP/nightly-notes.md" \
+              --prerelease
+          else
+            gh release create "$tag" \
+              --repo "$GITHUB_REPOSITORY" \
+              --verify-tag \
+              --title "${{ steps.state.outputs.title }}" \
+              --notes-file "$RUNNER_TEMP/nightly-notes.md" \
+              --prerelease \
+              --latest=false
+          fi
+      - name: Refresh moving nightly alias
         if: steps.state.outputs.publish == 'true'
         run: |
           if gh release view nightly --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             gh release delete nightly --repo "$GITHUB_REPOSITORY" -y
           fi
           git push origin :refs/tags/nightly || true
+          git tag -d nightly >/dev/null 2>&1 || true
           GIT_COMMITTER_NAME='github-actions[bot]' \
           GIT_COMMITTER_EMAIL='41898282+github-actions[bot]@users.noreply.github.com' \
           git tag -a nightly "${{ steps.run.outputs.head_sha }}" -m nightly
@@ -95,6 +143,6 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --verify-tag \
             --title "${{ steps.state.outputs.title }}" \
-            --notes-file "$RUNNER_TEMP/nightly-notes.md" \
+            --notes-file "$RUNNER_TEMP/nightly-alias-notes.md" \
             --prerelease \
             --latest=false

--- a/scripts/release-version.sh
+++ b/scripts/release-version.sh
@@ -6,7 +6,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 FLAKE_FILE="${MOSAIC_FLAKE_FILE:-$ROOT_DIR/flake.nix}"
 
 usage() {
-  printf '%s\n' "usage: $0 <get|set|assert-stable|assert-dev|next-patch-dev|tag|base> [version]" >&2
+  printf '%s\n' "usage: $0 <get|set|assert-stable|assert-dev|next-patch-dev|tag|base|nightly-tag> [version] [sha]" >&2
 }
 
 read_version() {
@@ -37,6 +37,13 @@ assert_stable() {
 assert_dev() {
   is_dev "$1" || {
     printf '%s\n' "mosaic: expected dev semver, got $1" >&2
+    return 1
+  }
+}
+
+assert_git_sha() {
+  [[ "$1" =~ ^[0-9a-fA-F]{7,40}$ ]] || {
+    printf '%s\n' "mosaic: expected git sha, got $1" >&2
     return 1
   }
 }
@@ -85,8 +92,17 @@ release_tag() {
   printf '%s\n' "v$1"
 }
 
+nightly_tag() {
+  local version="$1" sha="$2"
+  assert_dev "$version"
+  assert_git_sha "$sha"
+  sha="${sha,,}"
+  printf '%s\n' "nightly-$version-${sha:0:7}"
+}
+
 cmd="${1:-}"
 arg="${2:-}"
+arg2="${3:-}"
 
 case "$cmd" in
 get)
@@ -113,6 +129,16 @@ tag)
   ;;
 base)
   base_version "${arg:-$(read_version)}"
+  ;;
+nightly-tag)
+  if [ -n "$arg2" ]; then
+    nightly_tag "$arg" "$arg2"
+  elif [ -n "$arg" ]; then
+    nightly_tag "$(read_version)" "$arg"
+  else
+    usage
+    exit 1
+  fi
   ;;
 *)
   usage

--- a/tests/integration/release_version.bats
+++ b/tests/integration/release_version.bats
@@ -63,3 +63,14 @@ EOF
   [ "$status" -eq 0 ]
   [ "$output" = "v0.1.0" ]
 }
+
+@test "release-version: nightly-tag embeds the dev version and short sha" {
+  run env MOSAIC_FLAKE_FILE="$BATS_TEST_TMPDIR/flake.nix" "$RELEASE_SCRIPT" nightly-tag 0123456789abcdef0123456789abcdef01234567
+  [ "$status" -eq 0 ]
+  [ "$output" = "nightly-0.1.0-dev-0123456" ]
+}
+
+@test "release-version: nightly-tag rejects stable versions" {
+  run env MOSAIC_FLAKE_FILE="$BATS_TEST_TMPDIR/flake.nix" "$RELEASE_SCRIPT" nightly-tag 0.1.0 0123456789abcdef0123456789abcdef01234567
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Problem

The nightly workflow only had a single mutable `nightly` tag and prerelease. That made nightlies lose per-commit provenance, and it also left the workflow vulnerable to tag recreation failures like `fatal: tag 'nightly' already exists` when the local alias tag was still present.

## Solution

Publish an immutable nightly tag and prerelease for each dev commit using `nightly-<version>-<shortsha>`, keep `nightly` as a moving alias that points at the same commit, and teach the workflow to skip only when both the immutable and alias releases already match the target SHA. The release helper now generates deterministic nightly tag names, the workflow deletes any stale local `nightly` tag before recreating the alias, and the release-process doc explains the new model. Local verification covered `direnv exec /home/barrett/dev/tmux-mosaic just test-one 'release-version:'`, `direnv exec /home/barrett/dev/tmux-mosaic just format`, `direnv exec /home/barrett/dev/tmux-mosaic just lint`, and an isolated rerun of the known noisy `drag-resize in top orientation syncs mfact from height` test after one unrelated parallel-suite flake.
