### PR TITLE
refactor(shell): consolidate reusable layout helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A tmux plugin that applies tiling layouts, tracks which panes belong to them, an
 ## Dependencies
 
 - [tmux](https://github.com/tmux/tmux) 3.2+
-- [bash](https://git.savannah.gnu.org/cgit/bash.git)
+- [bash](https://git.savannah.gnu.org/cgit/bash.git) 3.2+
 
 ## Installation
 

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -269,22 +269,25 @@ _mosaic_window_has_foreign_panes() {
   return 1
 }
 
+_mosaic_window_guard_layout() {
+  local win="$1"
+  if _mosaic_window_has_layout "$win"; then
+    return 0
+  fi
+  _mosaic_window_ownership_clear "$win"
+  return 1
+}
+
 _mosaic_window_stamp_current_panes() {
   local win generation pane
   win=$(_mosaic_resolve_window "${1:-}")
   generation="${2:?generation required}"
   while IFS= read -r pane; do
     [[ -n "$pane" ]] || continue
-    if ! _mosaic_window_has_layout "$win"; then
-      _mosaic_window_ownership_clear "$win"
-      return 1
-    fi
+    _mosaic_window_guard_layout "$win" || return 1
     _mosaic_pane_owner_generation_set "$pane" "$generation"
   done < <(_mosaic_window_panes "$win")
-  if ! _mosaic_window_has_layout "$win"; then
-    _mosaic_window_ownership_clear "$win"
-    return 1
-  fi
+  _mosaic_window_guard_layout "$win"
 }
 
 _mosaic_window_adopt_current_panes() {
@@ -292,20 +295,11 @@ _mosaic_window_adopt_current_panes() {
   win=$(_mosaic_resolve_window "${1:-}")
   _mosaic_window_has_layout "$win" || return 1
   generation=$(_mosaic_window_generation_ensure "$win")
-  if ! _mosaic_window_has_layout "$win"; then
-    _mosaic_window_ownership_clear "$win"
-    return 1
-  fi
+  _mosaic_window_guard_layout "$win" || return 1
   _mosaic_window_stamp_current_panes "$win" "$generation" || return 1
-  if ! _mosaic_window_has_layout "$win"; then
-    _mosaic_window_ownership_clear "$win"
-    return 1
-  fi
+  _mosaic_window_guard_layout "$win" || return 1
   _mosaic_window_state_set "$win" "managed"
-  if ! _mosaic_window_has_layout "$win"; then
-    _mosaic_window_ownership_clear "$win"
-    return 1
-  fi
+  _mosaic_window_guard_layout "$win"
 }
 
 _mosaic_window_adopt_current_panes_refresh() {
@@ -313,20 +307,11 @@ _mosaic_window_adopt_current_panes_refresh() {
   win=$(_mosaic_resolve_window "${1:-}")
   _mosaic_window_has_layout "$win" || return 1
   generation=$(_mosaic_window_generation_rotate "$win")
-  if ! _mosaic_window_has_layout "$win"; then
-    _mosaic_window_ownership_clear "$win"
-    return 1
-  fi
+  _mosaic_window_guard_layout "$win" || return 1
   _mosaic_window_stamp_current_panes "$win" "$generation" || return 1
-  if ! _mosaic_window_has_layout "$win"; then
-    _mosaic_window_ownership_clear "$win"
-    return 1
-  fi
+  _mosaic_window_guard_layout "$win" || return 1
   _mosaic_window_state_set "$win" "managed"
-  if ! _mosaic_window_has_layout "$win"; then
-    _mosaic_window_ownership_clear "$win"
-    return 1
-  fi
+  _mosaic_window_guard_layout "$win"
 }
 
 _mosaic_window_refresh_state() {
@@ -439,6 +424,13 @@ _mosaic_sync_mfact() {
   current=$(_mosaic_get_w_raw "@mosaic-mfact" "$win")
   [[ "$current" == "$pct" ]] && return 0
   tmux set-option -wq -t "$win" "@mosaic-mfact" "$pct"
+}
+
+_mosaic_clamp_percent() {
+  local pct="$1"
+  [[ "$pct" -lt 5 ]] && pct=5
+  [[ "$pct" -gt 95 ]] && pct=95
+  printf '%s\n' "$pct"
 }
 
 _mosaic_show_message() {
@@ -568,8 +560,21 @@ _mosaic_relayout_simple() {
 
 _mosaic_current_pane_index() { tmux display-message -p '#{pane_index}'; }
 
+_mosaic_window_pane_base() {
+  tmux display-message -p -t "$(_mosaic_resolve_window "${1:-}")" '#{e|+|:0,#{?pane-base-index,#{pane-base-index},0}}'
+}
+
 _mosaic_current_pane_base() {
-  tmux display-message -p '#{e|+|:0,#{?pane-base-index,#{pane-base-index},0}}'
+  _mosaic_window_pane_base
+}
+
+_mosaic_resize_master_current_window() {
+  local delta="${1:-}" win cur new
+  [[ -n "$delta" ]] || delta=$(_mosaic_get "@mosaic-step" "5")
+  win=$(_mosaic_current_window)
+  cur=$(_mosaic_mfact_for "$win")
+  new=$(_mosaic_clamp_percent "$((cur + delta))")
+  tmux set-option -wq -t "$win" "@mosaic-mfact" "$new"
 }
 
 _mosaic_swap_keep_focus() {
@@ -606,7 +611,7 @@ _mosaic_fibonacci_variant() {
   fi
 }
 
-_mosaic_fibonacci_layout_checksum() {
+_mosaic_layout_checksum() {
   local layout="$1" csum=0 i ch
   for ((i = 0; i < ${#layout}; i++)); do
     printf -v ch '%d' "'${layout:i:1}"
@@ -616,12 +621,56 @@ _mosaic_fibonacci_layout_checksum() {
   printf '%04x\n' "$csum"
 }
 
-_mosaic_fibonacci_layout_leaf_id=0
+_mosaic_layout_leaf_id=0
 
-_mosaic_fibonacci_layout_leaf() {
-  local __out="$1" sx="$2" sy="$3" x="$4" y="$5" id="$_mosaic_fibonacci_layout_leaf_id"
-  _mosaic_fibonacci_layout_leaf_id=$((_mosaic_fibonacci_layout_leaf_id + 1))
+_mosaic_layout_leaf_reset() {
+  _mosaic_layout_leaf_id=0
+}
+
+_mosaic_layout_leaf() {
+  local __out="$1" sx="$2" sy="$3" x="$4" y="$5" id="$_mosaic_layout_leaf_id"
+  _mosaic_layout_leaf_id=$((_mosaic_layout_leaf_id + 1))
   printf -v "$__out" '%sx%s,%s,%s,%s' "$sx" "$sy" "$x" "$y" "$id"
+}
+
+_mosaic_layout_split_sizes() {
+  local total="$1" count="$2" usable base rem i size out=()
+  if [[ "$count" -le 1 ]]; then
+    printf '%s\n' "$total"
+    return
+  fi
+  usable=$((total - count + 1))
+  base=$((usable / count))
+  rem=$((usable % count))
+  for ((i = 0; i < count; i++)); do
+    size=$base
+    [[ "$i" -lt "$rem" ]] && size=$((size + 1))
+    out+=("$size")
+  done
+  printf '%s\n' "${out[*]}"
+}
+
+_mosaic_layout_column() {
+  local __out="$1" sx="$2" sy="$3" x="$4" y="$5" count="$6"
+  local node leaf size ycur
+  local -a sizes=()
+
+  if [[ "$count" -eq 1 ]]; then
+    _mosaic_layout_leaf node "$sx" "$sy" "$x" "$y"
+    printf -v "$__out" '%s' "$node"
+    return
+  fi
+
+  read -r -a sizes <<<"$(_mosaic_layout_split_sizes "$sy" "$count")"
+  node="${sx}x${sy},${x},${y}["
+  ycur=$y
+  for size in "${sizes[@]}"; do
+    _mosaic_layout_leaf leaf "$sx" "$size" "$x" "$ycur"
+    node+="$leaf,"
+    ycur=$((ycur + size + 1))
+  done
+  node="${node%,}]"
+  printf -v "$__out" '%s' "$node"
 }
 
 _mosaic_fibonacci_layout_split_master() {
@@ -725,7 +774,7 @@ _mosaic_fibonacci_layout_node() {
   local node_a_var="${__out}_a" node_b_var="${__out}_b" first_size second_size
 
   if [[ "$n" -eq 1 ]]; then
-    _mosaic_fibonacci_layout_leaf "$__out" "$sx" "$sy" "$x" "$y"
+    _mosaic_layout_leaf "$__out" "$sx" "$sy" "$x" "$y"
     return
   fi
 
@@ -750,19 +799,19 @@ _mosaic_fibonacci_layout_node() {
 
   if [[ "$axis" == "x" ]]; then
     if [[ "$order" == "leaf-node" ]]; then
-      _mosaic_fibonacci_layout_leaf "$node_a_var" "$first_size" "$sy" "$x" "$y"
+      _mosaic_layout_leaf "$node_a_var" "$first_size" "$sy" "$x" "$y"
       _mosaic_fibonacci_layout_node "$node_b_var" "$second_size" "$sy" "$((x + first_size + 1))" "$y" "$((n - 1))" "$next" "$mfact"
     else
       _mosaic_fibonacci_layout_node "$node_a_var" "$first_size" "$sy" "$x" "$y" "$((n - 1))" "$next" "$mfact"
-      _mosaic_fibonacci_layout_leaf "$node_b_var" "$second_size" "$sy" "$((x + first_size + 1))" "$y"
+      _mosaic_layout_leaf "$node_b_var" "$second_size" "$sy" "$((x + first_size + 1))" "$y"
     fi
   else
     if [[ "$order" == "leaf-node" ]]; then
-      _mosaic_fibonacci_layout_leaf "$node_a_var" "$sx" "$first_size" "$x" "$y"
+      _mosaic_layout_leaf "$node_a_var" "$sx" "$first_size" "$x" "$y"
       _mosaic_fibonacci_layout_node "$node_b_var" "$sx" "$second_size" "$x" "$((y + first_size + 1))" "$((n - 1))" "$next" "$mfact"
     else
       _mosaic_fibonacci_layout_node "$node_a_var" "$sx" "$first_size" "$x" "$y" "$((n - 1))" "$next" "$mfact"
-      _mosaic_fibonacci_layout_leaf "$node_b_var" "$sx" "$second_size" "$x" "$((y + first_size + 1))"
+      _mosaic_layout_leaf "$node_b_var" "$sx" "$second_size" "$x" "$((y + first_size + 1))"
     fi
   fi
 
@@ -776,7 +825,7 @@ _mosaic_fibonacci_layout_node() {
 _mosaic_fibonacci_layout_body() {
   local __out="$1" sx="$2" sy="$3" n="$4" mfact="$5"
   local layout
-  _mosaic_fibonacci_layout_leaf_id=0
+  _mosaic_layout_leaf_reset
   _mosaic_fibonacci_layout_node layout "$sx" "$sy" 0 0 "$n" 0 "$mfact"
   printf -v "$__out" '%s' "$layout"
 }
@@ -788,7 +837,7 @@ _mosaic_fibonacci_apply_layout() {
   sy=$(tmux display-message -p -t "$win" '#{window_height}' 2>/dev/null)
   [[ -z "$sx" || -z "$sy" ]] && return 0
   _mosaic_fibonacci_layout_body body "$sx" "$sy" "$n" "$mfact"
-  tmux select-layout -t "$win" "$(_mosaic_fibonacci_layout_checksum "$body"),$body" 2>/dev/null || true
+  tmux select-layout -t "$win" "$(_mosaic_layout_checksum "$body"),$body" 2>/dev/null || true
 }
 
 _mosaic_fibonacci_relayout() {
@@ -798,7 +847,7 @@ _mosaic_fibonacci_relayout() {
   n=$(_mosaic_window_pane_count "$win")
   _mosaic_can_relayout_window "$win" "$n" || return 0
   mfact=$(_mosaic_mfact_for "$win")
-  pbase=$(_mosaic_current_pane_base)
+  pbase=$(_mosaic_window_pane_base "$win")
 
   _mosaic_fibonacci_apply_layout "$win" "$n" "$mfact"
 
@@ -823,17 +872,7 @@ _mosaic_fibonacci_promote() {
 }
 
 _mosaic_fibonacci_resize_master() {
-  local delta="${1:-}"
-  if [[ -z "$delta" ]]; then
-    delta=$(_mosaic_get "@mosaic-step" "5")
-  fi
-  local win cur new
-  win=$(_mosaic_current_window)
-  cur=$(_mosaic_mfact_for "$win")
-  new=$((cur + delta))
-  [[ "$new" -lt 5 ]] && new=5
-  [[ "$new" -gt 95 ]] && new=95
-  tmux set-option -wq -t "$win" "@mosaic-mfact" "$new"
+  _mosaic_resize_master_current_window "$@"
 }
 
 _mosaic_fibonacci_sync_state() {
@@ -847,15 +886,13 @@ _mosaic_fibonacci_sync_state() {
   [[ "$n" -le 1 ]] && return 0
 
   local pbase pane_size window_size pct
-  pbase=$(_mosaic_current_pane_base)
+  pbase=$(_mosaic_window_pane_base "$win")
   pane_size=$(tmux display-message -p -t "$win.$pbase" '#{pane_width}' 2>/dev/null)
   window_size=$(tmux display-message -p -t "$win" '#{window_width}' 2>/dev/null)
   [[ -z "$pane_size" ]] && return 0
   [[ -z "$window_size" || "$window_size" -le 0 ]] && return 0
 
-  pct=$((pane_size * 100 / window_size))
-  [[ "$pct" -lt 5 ]] && pct=5
-  [[ "$pct" -gt 95 ]] && pct=95
+  pct=$(_mosaic_clamp_percent "$((pane_size * 100 / window_size))")
 
   _mosaic_sync_mfact "$win" "$pct"
   _mosaic_log "sync-state: win=$win layout=$variant pbase=$pbase pane_size=$pane_size window_size=$window_size pct=$pct"

--- a/scripts/layouts/centered-master.sh
+++ b/scripts/layouts/centered-master.sh
@@ -1,81 +1,19 @@
 #!/usr/bin/env bash
 
-_layout_pane_count() { tmux display-message -p '#{window_panes}'; }
-_layout_pane_index() { tmux display-message -p '#{pane_index}'; }
-_layout_pane_base() { tmux display-message -p '#{e|+|:0,#{?pane-base-index,#{pane-base-index},0}}'; }
-
-_layout_layout_checksum() {
-  local layout="$1" csum=0 i ch
-  for ((i = 0; i < ${#layout}; i++)); do
-    printf -v ch '%d' "'${layout:i:1}"
-    csum=$(((csum >> 1) | ((csum & 1) << 15)))
-    csum=$(((csum + ch) & 0xffff))
-  done
-  printf '%04x\n' "$csum"
-}
-
-_layout_layout_leaf_id=0
-
-_layout_layout_leaf() {
-  local __out="$1" sx="$2" sy="$3" x="$4" y="$5" id="$_layout_layout_leaf_id"
-  _layout_layout_leaf_id=$((_layout_layout_leaf_id + 1))
-  printf -v "$__out" '%sx%s,%s,%s,%s' "$sx" "$sy" "$x" "$y" "$id"
-}
-
-_layout_layout_split_sizes() {
-  local total="$1" count="$2" usable base rem i size out=()
-  if [[ "$count" -le 1 ]]; then
-    printf '%s\n' "$total"
-    return
-  fi
-  usable=$((total - count + 1))
-  base=$((usable / count))
-  rem=$((usable % count))
-  for ((i = 0; i < count; i++)); do
-    size=$base
-    [[ "$i" -lt "$rem" ]] && size=$((size + 1))
-    out+=("$size")
-  done
-  printf '%s\n' "${out[*]}"
-}
-
-_layout_layout_column() {
-  local __out="$1" sx="$2" sy="$3" x="$4" y="$5" count="$6"
-  local node leaf size ycur
-  local -a sizes=()
-
-  if [[ "$count" -eq 1 ]]; then
-    _layout_layout_leaf node "$sx" "$sy" "$x" "$y"
-    printf -v "$__out" '%s' "$node"
-    return
-  fi
-
-  read -r -a sizes <<<"$(_layout_layout_split_sizes "$sy" "$count")"
-  node="${sx}x${sy},${x},${y}["
-  ycur=$y
-  for size in "${sizes[@]}"; do
-    _layout_layout_leaf leaf "$sx" "$size" "$x" "$ycur"
-    node+="$leaf,"
-    ycur=$((ycur + size + 1))
-  done
-  node="${node%,}]"
-  printf -v "$__out" '%s' "$node"
-}
-
 _layout_layout_body() {
   local __out="$1" sx="$2" sy="$3" n="$4" nmaster="$5" mfact="$6"
   local stack mw maxw sw left_w right_w left_n right_n layout master left right
 
-  _layout_layout_leaf_id=0
+  _mosaic_layout_leaf_reset
 
   if [[ "$n" -eq 1 ]]; then
-    _layout_layout_leaf layout "$sx" "$sy" 0 0
+    _mosaic_layout_leaf layout "$sx" "$sy" 0 0
     printf -v "$__out" '%s' "$layout"
     return
   fi
 
   if [[ "$nmaster" -ge "$n" ]]; then
-    _layout_layout_column layout "$sx" "$sy" 0 0 "$n"
+    _mosaic_layout_column layout "$sx" "$sy" 0 0 "$n"
     printf -v "$__out" '%s' "$layout"
     return
   fi
@@ -89,8 +27,8 @@ _layout_layout_body() {
     [[ "$mw" -gt "$maxw" ]] && mw=$maxw
     [[ "$mw" -lt 1 ]] && mw=1
     sw=$((sx - mw - 1))
-    _layout_layout_column master "$mw" "$sy" 0 0 "$nmaster"
-    _layout_layout_column right "$sw" "$sy" "$((mw + 1))" 0 "$stack"
+    _mosaic_layout_column master "$mw" "$sy" 0 0 "$nmaster"
+    _mosaic_layout_column right "$sw" "$sy" "$((mw + 1))" 0 "$stack"
     layout="${sx}x${sy},0,0{$master,$right}"
     printf -v "$__out" '%s' "$layout"
     return
@@ -106,9 +44,9 @@ _layout_layout_body() {
   right_n=$(((stack + 1) / 2))
   left_n=$((stack / 2))
 
-  _layout_layout_column left "$left_w" "$sy" 0 0 "$left_n"
-  _layout_layout_column master "$mw" "$sy" "$((left_w + 1))" 0 "$nmaster"
-  _layout_layout_column right "$right_w" "$sy" "$((left_w + mw + 2))" 0 "$right_n"
+  _mosaic_layout_column left "$left_w" "$sy" 0 0 "$left_n"
+  _mosaic_layout_column master "$mw" "$sy" "$((left_w + 1))" 0 "$nmaster"
+  _mosaic_layout_column right "$right_w" "$sy" "$((left_w + mw + 2))" 0 "$right_n"
   layout="${sx}x${sy},0,0{$left,$master,$right}"
   printf -v "$__out" '%s' "$layout"
 }
@@ -120,7 +58,7 @@ _layout_apply_layout() {
   sy=$(tmux display-message -p -t "$win" '#{window_height}' 2>/dev/null)
   [[ -z "$sx" || -z "$sy" ]] && return 0
   _layout_layout_body body "$sx" "$sy" "$n" "$nmaster" "$mfact"
-  tmux select-layout -t "$win" "$(_layout_layout_checksum "$body"),$body" 2>/dev/null || true
+  tmux select-layout -t "$win" "$(_mosaic_layout_checksum "$body"),$body" 2>/dev/null || true
 }
 
 _layout_left_stack_count() {
@@ -156,7 +94,7 @@ _layout_relayout() {
   _mosaic_can_relayout_window "$win" "$n" || return 0
   mfact=$(_mosaic_mfact_for "$win")
   nmaster=$(_mosaic_effective_nmaster "$win" "$n")
-  pbase=$(_layout_pane_base)
+  pbase=$(_mosaic_window_pane_base "$win")
   master_base=$(_layout_master_base "$n" "$nmaster" "$pbase")
 
   _layout_apply_layout "$win" "$n" "$nmaster" "$mfact"
@@ -164,7 +102,6 @@ _layout_relayout() {
   _mosaic_log "relayout: win=$win n=$n layout=centered-master nmaster=$nmaster mfact=$mfact pbase=$pbase master_base=$master_base"
 }
 
-_layout_toggle() { _mosaic_toggle_window; }
 _layout_new_pane() {
   local win n nmaster target
   local -a flags=()
@@ -182,11 +119,11 @@ _layout_new_pane() {
 
 _layout_promote() {
   local idx n win nmaster pbase master_base stack_top
-  idx=$(_layout_pane_index)
+  idx=$(_mosaic_current_pane_index)
   win=$(_mosaic_current_window)
   n=$(_mosaic_window_pane_count "$win")
   nmaster=$(_mosaic_effective_nmaster "$win" "$n")
-  pbase=$(_layout_pane_base)
+  pbase=$(_mosaic_window_pane_base "$win")
   master_base=$(_layout_master_base "$n" "$nmaster" "$pbase")
 
   [[ "$n" -le 1 ]] && return 0
@@ -205,17 +142,7 @@ _layout_promote() {
 }
 
 _layout_resize_master() {
-  local delta="${1:-}"
-  if [[ -z "$delta" ]]; then
-    delta=$(_mosaic_get "@mosaic-step" "5")
-  fi
-  local win cur new
-  win=$(_mosaic_current_window)
-  cur=$(_mosaic_mfact_for "$win")
-  new=$((cur + delta))
-  [[ "$new" -lt 5 ]] && new=5
-  [[ "$new" -gt 95 ]] && new=95
-  tmux set-option -wq -t "$win" "@mosaic-mfact" "$new"
+  _mosaic_resize_master_current_window "$@"
 }
 
 _layout_sync_state() {
@@ -230,16 +157,14 @@ _layout_sync_state() {
   [[ "$nmaster" -ge "$n" ]] && return 0
 
   local pbase master_base pane_size window_size pct
-  pbase=$(_layout_pane_base)
+  pbase=$(_mosaic_window_pane_base "$win")
   master_base=$(_layout_master_base "$n" "$nmaster" "$pbase")
   pane_size=$(tmux display-message -p -t "$win.$master_base" '#{pane_width}' 2>/dev/null)
   window_size=$(tmux display-message -p -t "$win" '#{window_width}' 2>/dev/null)
   [[ -z "$pane_size" ]] && return 0
   [[ -z "$window_size" || "$window_size" -le 0 ]] && return 0
 
-  pct=$((pane_size * 100 / window_size))
-  [[ "$pct" -lt 5 ]] && pct=5
-  [[ "$pct" -gt 95 ]] && pct=95
+  pct=$(_mosaic_clamp_percent "$((pane_size * 100 / window_size))")
 
   _mosaic_sync_mfact "$win" "$pct"
   _mosaic_log "sync-state: win=$win layout=centered-master master_base=$master_base pane_size=$pane_size window_size=$window_size pct=$pct"

--- a/scripts/layouts/dwindle.sh
+++ b/scripts/layouts/dwindle.sh
@@ -3,7 +3,6 @@
 _layout_fibonacci_variant() { printf '%s\n' "dwindle"; }
 
 _layout_relayout() { _mosaic_fibonacci_relayout "$@"; }
-_layout_toggle() { _mosaic_toggle_window; }
 _layout_new_pane() { _mosaic_fibonacci_new_pane "$1"; }
 _layout_promote() { _mosaic_fibonacci_promote; }
 _layout_resize_master() { _mosaic_fibonacci_resize_master "$@"; }

--- a/scripts/layouts/even-horizontal.sh
+++ b/scripts/layouts/even-horizontal.sh
@@ -2,7 +2,6 @@
 
 _layout_relayout() { _mosaic_relayout_simple even-horizontal "${1:-}"; }
 
-_layout_toggle() { _mosaic_toggle_window; }
 _layout_new_pane() {
   _mosaic_new_pane_split_or_append "${1:-}" "$(_mosaic_window_last_pane "${1:-}")" -h
 }

--- a/scripts/layouts/even-vertical.sh
+++ b/scripts/layouts/even-vertical.sh
@@ -2,7 +2,6 @@
 
 _layout_relayout() { _mosaic_relayout_simple even-vertical "${1:-}"; }
 
-_layout_toggle() { _mosaic_toggle_window; }
 _layout_new_pane() {
   _mosaic_new_pane_split_or_append "${1:-}" "$(_mosaic_window_last_pane "${1:-}")"
 }

--- a/scripts/layouts/grid.sh
+++ b/scripts/layouts/grid.sh
@@ -13,7 +13,6 @@ _layout_global_reshape_count() {
   return 1
 }
 
-_layout_toggle() { _mosaic_toggle_window; }
 _layout_new_pane() {
   local win n target
   win=$(_mosaic_resolve_window "${1:-}")

--- a/scripts/layouts/master-stack.sh
+++ b/scripts/layouts/master-stack.sh
@@ -1,50 +1,46 @@
 #!/usr/bin/env bash
 
-_layout_pane_count() { tmux display-message -p '#{window_panes}'; }
-_layout_pane_index() { tmux display-message -p '#{pane_index}'; }
-_layout_pane_base() { tmux display-message -p '#{e|+|:0,#{?pane-base-index,#{pane-base-index},0}}'; }
-
 _layout_orientation_for() {
   local win="$1" val
   val=$(_mosaic_get_w "@mosaic-orientation" "left" "$win")
   case "$val" in
   left | right | top | bottom)
-    echo "$val"
+    printf '%s\n' "$val"
     ;;
   *)
     _mosaic_log "orientation: invalid=$val win=$win defaulting=left"
-    echo "left"
+    printf '%s\n' "left"
     ;;
   esac
 }
 
 _layout_layout_for() {
   case "$1" in
-  left) echo "main-vertical" ;;
-  right) echo "main-vertical-mirrored" ;;
-  top) echo "main-horizontal" ;;
-  bottom) echo "main-horizontal-mirrored" ;;
+  left) printf '%s\n' "main-vertical" ;;
+  right) printf '%s\n' "main-vertical-mirrored" ;;
+  top) printf '%s\n' "main-horizontal" ;;
+  bottom) printf '%s\n' "main-horizontal-mirrored" ;;
   esac
 }
 
 _layout_master_pane_option_for() {
   case "$1" in
-  left | right) echo "main-pane-width" ;;
-  top | bottom) echo "main-pane-height" ;;
+  left | right) printf '%s\n' "main-pane-width" ;;
+  top | bottom) printf '%s\n' "main-pane-height" ;;
   esac
 }
 
 _layout_full_layout_for() {
   case "$1" in
-  left | right) echo "even-vertical" ;;
-  top | bottom) echo "even-horizontal" ;;
+  left | right) printf '%s\n' "even-vertical" ;;
+  top | bottom) printf '%s\n' "even-horizontal" ;;
   esac
 }
 
 _layout_join_flag_for() {
   case "$1" in
-  left | right) echo "-v" ;;
-  top | bottom) echo "-h" ;;
+  left | right) printf '%s\n' "-v" ;;
+  top | bottom) printf '%s\n' "-h" ;;
   esac
 }
 
@@ -83,7 +79,7 @@ _layout_relayout() {
   mfact=$(_mosaic_mfact_for "$win")
   orientation=$(_layout_orientation_for "$win")
   nmaster=$(_mosaic_effective_nmaster "$win" "$n")
-  pbase=$(_layout_pane_base)
+  pbase=$(_mosaic_window_pane_base "$win")
 
   _layout_apply_layout "$win" "$orientation" "$mfact"
   if [[ "$nmaster" -ge "$n" ]]; then
@@ -126,7 +122,6 @@ _layout_new_pane_all_masters() {
   printf '%s\n' "$pane"
 }
 
-_layout_toggle() { _mosaic_toggle_window; }
 _layout_new_pane() {
   local win n nmaster orientation target pbase
   local -a flags=()
@@ -144,7 +139,7 @@ _layout_new_pane() {
   fi
   orientation=$(_layout_orientation_for "$win")
   if [[ "$n" -eq "$nmaster" ]]; then
-    pbase=$(_layout_pane_base)
+    pbase=$(_mosaic_window_pane_base "$win")
     _layout_new_pane_all_masters "$win" "$orientation" "$n" "$pbase"
     return
   fi
@@ -157,9 +152,9 @@ _layout_new_pane() {
 
 _layout_promote() {
   local idx n pbase
-  idx=$(_layout_pane_index)
-  n=$(_layout_pane_count)
-  pbase=$(_layout_pane_base)
+  idx=$(_mosaic_current_pane_index)
+  n=$(_mosaic_window_pane_count)
+  pbase=$(_mosaic_window_pane_base)
 
   [[ "$n" -le 1 ]] && return 0
 
@@ -172,17 +167,7 @@ _layout_promote() {
 }
 
 _layout_resize_master() {
-  local delta="${1:-}"
-  if [[ -z "$delta" ]]; then
-    delta=$(_mosaic_get "@mosaic-step" "5")
-  fi
-  local win cur new
-  win=$(_mosaic_current_window)
-  cur=$(_mosaic_mfact_for "$win")
-  new=$((cur + delta))
-  [[ "$new" -lt 5 ]] && new=5
-  [[ "$new" -gt 95 ]] && new=95
-  tmux set-option -wq -t "$win" "@mosaic-mfact" "$new"
+  _mosaic_resize_master_current_window "$@"
 }
 
 _layout_sync_state() {
@@ -198,7 +183,7 @@ _layout_sync_state() {
 
   local pbase pane_size window_size pct orientation
   orientation=$(_layout_orientation_for "$win")
-  pbase=$(_layout_pane_base)
+  pbase=$(_mosaic_window_pane_base "$win")
   case "$orientation" in
   left | right)
     pane_size=$(tmux display-message -p -t "$win.$pbase" '#{pane_width}' 2>/dev/null)
@@ -212,9 +197,7 @@ _layout_sync_state() {
   [[ -z "$pane_size" ]] && return 0
   [[ -z "$window_size" || "$window_size" -le 0 ]] && return 0
 
-  pct=$((pane_size * 100 / window_size))
-  [[ "$pct" -lt 5 ]] && pct=5
-  [[ "$pct" -gt 95 ]] && pct=95
+  pct=$(_mosaic_clamp_percent "$((pane_size * 100 / window_size))")
 
   _mosaic_sync_mfact "$win" "$pct"
   _mosaic_log "sync-state: win=$win orientation=$orientation pane_size=$pane_size window_size=$window_size pct=$pct"

--- a/scripts/layouts/monocle.sh
+++ b/scripts/layouts/monocle.sh
@@ -13,5 +13,4 @@ _layout_relayout() {
   _mosaic_log "relayout: win=$win n=$n zoomed=$zoomed"
 }
 
-_layout_toggle() { _mosaic_toggle_window; }
 _layout_new_pane() { _mosaic_new_pane_append "$1"; }

--- a/scripts/layouts/spiral.sh
+++ b/scripts/layouts/spiral.sh
@@ -3,7 +3,6 @@
 _layout_fibonacci_variant() { printf '%s\n' "spiral"; }
 
 _layout_relayout() { _mosaic_fibonacci_relayout "$@"; }
-_layout_toggle() { _mosaic_toggle_window; }
 _layout_new_pane() { _mosaic_fibonacci_new_pane "$1"; }
 _layout_promote() { _mosaic_fibonacci_promote; }
 _layout_resize_master() { _mosaic_fibonacci_resize_master "$@"; }

--- a/scripts/layouts/three-column.sh
+++ b/scripts/layouts/three-column.sh
@@ -1,81 +1,19 @@
 #!/usr/bin/env bash
 
-_layout_pane_count() { tmux display-message -p '#{window_panes}'; }
-_layout_pane_index() { tmux display-message -p '#{pane_index}'; }
-_layout_pane_base() { tmux display-message -p '#{e|+|:0,#{?pane-base-index,#{pane-base-index},0}}'; }
-
-_layout_layout_checksum() {
-  local layout="$1" csum=0 i ch
-  for ((i = 0; i < ${#layout}; i++)); do
-    printf -v ch '%d' "'${layout:i:1}"
-    csum=$(((csum >> 1) | ((csum & 1) << 15)))
-    csum=$(((csum + ch) & 0xffff))
-  done
-  printf '%04x\n' "$csum"
-}
-
-_layout_layout_leaf_id=0
-
-_layout_layout_leaf() {
-  local __out="$1" sx="$2" sy="$3" x="$4" y="$5" id="$_layout_layout_leaf_id"
-  _layout_layout_leaf_id=$((_layout_layout_leaf_id + 1))
-  printf -v "$__out" '%sx%s,%s,%s,%s' "$sx" "$sy" "$x" "$y" "$id"
-}
-
-_layout_layout_split_sizes() {
-  local total="$1" count="$2" usable base rem i size out=()
-  if [[ "$count" -le 1 ]]; then
-    printf '%s\n' "$total"
-    return
-  fi
-  usable=$((total - count + 1))
-  base=$((usable / count))
-  rem=$((usable % count))
-  for ((i = 0; i < count; i++)); do
-    size=$base
-    [[ "$i" -lt "$rem" ]] && size=$((size + 1))
-    out+=("$size")
-  done
-  printf '%s\n' "${out[*]}"
-}
-
-_layout_layout_column() {
-  local __out="$1" sx="$2" sy="$3" x="$4" y="$5" count="$6"
-  local node leaf size ycur
-  local -a sizes=()
-
-  if [[ "$count" -eq 1 ]]; then
-    _layout_layout_leaf node "$sx" "$sy" "$x" "$y"
-    printf -v "$__out" '%s' "$node"
-    return
-  fi
-
-  read -r -a sizes <<<"$(_layout_layout_split_sizes "$sy" "$count")"
-  node="${sx}x${sy},${x},${y}["
-  ycur=$y
-  for size in "${sizes[@]}"; do
-    _layout_layout_leaf leaf "$sx" "$size" "$x" "$ycur"
-    node+="$leaf,"
-    ycur=$((ycur + size + 1))
-  done
-  node="${node%,}]"
-  printf -v "$__out" '%s' "$node"
-}
-
 _layout_layout_body() {
   local __out="$1" sx="$2" sy="$3" n="$4" nmaster="$5" mfact="$6"
   local stack mw maxw sw middle_w right_w middle_n right_n layout master middle right
 
-  _layout_layout_leaf_id=0
+  _mosaic_layout_leaf_reset
 
   if [[ "$n" -eq 1 ]]; then
-    _layout_layout_leaf layout "$sx" "$sy" 0 0
+    _mosaic_layout_leaf layout "$sx" "$sy" 0 0
     printf -v "$__out" '%s' "$layout"
     return
   fi
 
   if [[ "$nmaster" -ge "$n" ]]; then
-    _layout_layout_column layout "$sx" "$sy" 0 0 "$n"
+    _mosaic_layout_column layout "$sx" "$sy" 0 0 "$n"
     printf -v "$__out" '%s' "$layout"
     return
   fi
@@ -89,8 +27,8 @@ _layout_layout_body() {
     [[ "$mw" -gt "$maxw" ]] && mw=$maxw
     [[ "$mw" -lt 1 ]] && mw=1
     sw=$((sx - mw - 1))
-    _layout_layout_column master "$mw" "$sy" 0 0 "$nmaster"
-    _layout_layout_column right "$sw" "$sy" "$((mw + 1))" 0 "$stack"
+    _mosaic_layout_column master "$mw" "$sy" 0 0 "$nmaster"
+    _mosaic_layout_column right "$sw" "$sy" "$((mw + 1))" 0 "$stack"
     layout="${sx}x${sy},0,0{$master,$right}"
     printf -v "$__out" '%s' "$layout"
     return
@@ -106,9 +44,9 @@ _layout_layout_body() {
   middle_n=$(((stack + 1) / 2))
   right_n=$((stack - middle_n))
 
-  _layout_layout_column master "$mw" "$sy" 0 0 "$nmaster"
-  _layout_layout_column middle "$middle_w" "$sy" "$((mw + 1))" 0 "$middle_n"
-  _layout_layout_column right "$right_w" "$sy" "$((mw + middle_w + 2))" 0 "$right_n"
+  _mosaic_layout_column master "$mw" "$sy" 0 0 "$nmaster"
+  _mosaic_layout_column middle "$middle_w" "$sy" "$((mw + 1))" 0 "$middle_n"
+  _mosaic_layout_column right "$right_w" "$sy" "$((mw + middle_w + 2))" 0 "$right_n"
   layout="${sx}x${sy},0,0{$master,$middle,$right}"
   printf -v "$__out" '%s' "$layout"
 }
@@ -120,7 +58,7 @@ _layout_apply_layout() {
   sy=$(tmux display-message -p -t "$win" '#{window_height}' 2>/dev/null)
   [[ -z "$sx" || -z "$sy" ]] && return 0
   _layout_layout_body body "$sx" "$sy" "$n" "$nmaster" "$mfact"
-  tmux select-layout -t "$win" "$(_layout_layout_checksum "$body"),$body" 2>/dev/null || true
+  tmux select-layout -t "$win" "$(_mosaic_layout_checksum "$body"),$body" 2>/dev/null || true
 }
 
 _layout_relayout() {
@@ -130,14 +68,13 @@ _layout_relayout() {
   _mosaic_can_relayout_window "$win" "$n" || return 0
   mfact=$(_mosaic_mfact_for "$win")
   nmaster=$(_mosaic_effective_nmaster "$win" "$n")
-  pbase=$(_layout_pane_base)
+  pbase=$(_mosaic_window_pane_base "$win")
 
   _layout_apply_layout "$win" "$n" "$nmaster" "$mfact"
 
   _mosaic_log "relayout: win=$win n=$n layout=three-column nmaster=$nmaster mfact=$mfact pbase=$pbase"
 }
 
-_layout_toggle() { _mosaic_toggle_window; }
 _layout_new_pane() {
   local win n nmaster target
   local -a flags=()
@@ -155,11 +92,11 @@ _layout_new_pane() {
 
 _layout_promote() {
   local idx n win nmaster pbase stack_top
-  idx=$(_layout_pane_index)
+  idx=$(_mosaic_current_pane_index)
   win=$(_mosaic_current_window)
   n=$(_mosaic_window_pane_count "$win")
   nmaster=$(_mosaic_effective_nmaster "$win" "$n")
-  pbase=$(_layout_pane_base)
+  pbase=$(_mosaic_window_pane_base "$win")
 
   [[ "$n" -le 1 ]] && return 0
 
@@ -177,17 +114,7 @@ _layout_promote() {
 }
 
 _layout_resize_master() {
-  local delta="${1:-}"
-  if [[ -z "$delta" ]]; then
-    delta=$(_mosaic_get "@mosaic-step" "5")
-  fi
-  local win cur new
-  win=$(_mosaic_current_window)
-  cur=$(_mosaic_mfact_for "$win")
-  new=$((cur + delta))
-  [[ "$new" -lt 5 ]] && new=5
-  [[ "$new" -gt 95 ]] && new=95
-  tmux set-option -wq -t "$win" "@mosaic-mfact" "$new"
+  _mosaic_resize_master_current_window "$@"
 }
 
 _layout_sync_state() {
@@ -202,15 +129,13 @@ _layout_sync_state() {
   [[ "$nmaster" -ge "$n" ]] && return 0
 
   local pbase pane_size window_size pct
-  pbase=$(_layout_pane_base)
+  pbase=$(_mosaic_window_pane_base "$win")
   pane_size=$(tmux display-message -p -t "$win.$pbase" '#{pane_width}' 2>/dev/null)
   window_size=$(tmux display-message -p -t "$win" '#{window_width}' 2>/dev/null)
   [[ -z "$pane_size" ]] && return 0
   [[ -z "$window_size" || "$window_size" -le 0 ]] && return 0
 
-  pct=$((pane_size * 100 / window_size))
-  [[ "$pct" -lt 5 ]] && pct=5
-  [[ "$pct" -gt 95 ]] && pct=95
+  pct=$(_mosaic_clamp_percent "$((pane_size * 100 / window_size))")
 
   _mosaic_sync_mfact "$win" "$pct"
   _mosaic_log "sync-state: win=$win layout=three-column pbase=$pbase pane_size=$pane_size window_size=$window_size pct=$pct"

--- a/scripts/ops.sh
+++ b/scripts/ops.sh
@@ -159,7 +159,7 @@ dispatch_optional() {
 ensure_current || exit 0
 case "$cmd" in
 relayout | _on-set-option) _layout_relayout "$target_window" ;;
-toggle) _layout_toggle ;;
+toggle) _mosaic_toggle_window ;;
 _sync-state)
   if declare -f _layout_sync_state >/dev/null; then
     _layout_sync_state "$target_window"

--- a/scripts/release-version.sh
+++ b/scripts/release-version.sh
@@ -92,11 +92,15 @@ release_tag() {
   printf '%s\n' "v$1"
 }
 
+lowercase_sha() {
+  printf '%s\n' "$1" | LC_ALL=C tr '[:upper:]' '[:lower:]'
+}
+
 nightly_tag() {
   local version="$1" sha="$2"
   assert_dev "$version"
   assert_git_sha "$sha"
-  sha="${sha,,}"
+  sha=$(lowercase_sha "$sha")
   printf '%s\n' "nightly-$version-${sha:0:7}"
 }
 

--- a/tests/integration/release_version.bats
+++ b/tests/integration/release_version.bats
@@ -70,6 +70,12 @@ EOF
   [ "$output" = "nightly-0.1.0-dev-0123456" ]
 }
 
+@test "release-version: nightly-tag lowercases mixed-case shas" {
+  run env MOSAIC_FLAKE_FILE="$BATS_TEST_TMPDIR/flake.nix" "$RELEASE_SCRIPT" nightly-tag AbCdEf0123456789abcdef0123456789ABCDEF01
+  [ "$status" -eq 0 ]
+  [ "$output" = "nightly-0.1.0-dev-abcdef0" ]
+}
+
 @test "release-version: nightly-tag rejects stable versions" {
   run env MOSAIC_FLAKE_FILE="$BATS_TEST_TMPDIR/flake.nix" "$RELEASE_SCRIPT" nightly-tag 0.1.0 0123456789abcdef0123456789abcdef01234567
   [ "$status" -ne 0 ]


### PR DESCRIPTION
## Problem

The shell code carried repeated layout geometry, pane-base, resize, and toggle plumbing across multiple layout files, and the release helper still used a Bash-only lowercase expansion that kept the documented Bash floor looser than the implementation.

## Solution

Move shared layout and ownership helpers into `scripts/helpers.sh`, route toggle handling through the central dispatcher, reuse the shared helpers from the master-stack, centered-master, and three-column layouts, replace the nightly SHA lowercasing with a Bash-3.2-compatible `tr` path, add coverage for mixed-case SHAs, and document Bash 3.2+ in the README.