### PR TITLE
ci(shell): add a Bash 3.2 smoke check

### DIFF
--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -32,3 +32,10 @@ jobs:
       - uses: cachix/install-nix-action@v31
       - name: Test
         run: nix develop .#ci --command just test
+  bash32:
+    name: Bash 3.2
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Bash 3.2
+        run: docker run --rm -v "$GITHUB_WORKSPACE:/work" -w /work bash:3.2 bash scripts/bash32-smoke.sh

--- a/scripts/bash32-smoke.sh
+++ b/scripts/bash32-smoke.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+for f in mosaic.tmux scripts/*.sh scripts/layouts/*.sh tests/helpers.bash; do
+  bash -n "$f"
+done
+
+d=$(mktemp -d)
+trap 'rm -rf "$d"' EXIT
+
+cat >"$d/flake.nix" <<'EOF'
+{
+  packages = {
+    default = {
+      version = "0.1.0-dev";
+    };
+  };
+}
+EOF
+
+out=$(MOSAIC_FLAKE_FILE="$d/flake.nix" scripts/release-version.sh nightly-tag AbCdEf0123456789abcdef0123456789ABCDEF01)
+[ "$out" = "nightly-0.1.0-dev-abcdef0" ]


### PR DESCRIPTION
## Problem

The README now promises Bash 3.2+, but CI does not run any explicit check that keeps that floor enforced.

## Solution

Add a small Bash 3.2 smoke script and run it in the quality workflow via the `bash:3.2` container so syntax and the mixed-case nightly tag path stay covered.