### PR TITLE
refactor(shell): reduce layout helper indirection

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -603,8 +603,12 @@ _mosaic_bubble_keep_focus() {
   done
 }
 
+_mosaic_fn_defined() {
+  declare -f "$1" >/dev/null 2>&1
+}
+
 _mosaic_fibonacci_variant() {
-  if declare -f _layout_fibonacci_variant >/dev/null 2>&1; then
+  if _mosaic_fn_defined _layout_fibonacci_variant; then
     _layout_fibonacci_variant
   else
     printf '%s\n' "spiral"
@@ -630,6 +634,11 @@ _mosaic_layout_leaf_reset() {
 _mosaic_layout_leaf() {
   local __out="$1" sx="$2" sy="$3" x="$4" y="$5" id="$_mosaic_layout_leaf_id"
   _mosaic_layout_leaf_id=$((_mosaic_layout_leaf_id + 1))
+  printf -v "$__out" '%sx%s,%s,%s,%s' "$sx" "$sy" "$x" "$y" "$id"
+}
+
+_mosaic_layout_leaf_at() {
+  local __out="$1" sx="$2" sy="$3" x="$4" y="$5" id="$6"
   printf -v "$__out" '%sx%s,%s,%s,%s' "$sx" "$sy" "$x" "$y" "$id"
 }
 
@@ -769,12 +778,14 @@ _mosaic_fibonacci_new_pane() {
 }
 
 _mosaic_fibonacci_layout_node() {
-  local __out="$1" sx="$2" sy="$3" x="$4" y="$5" n="$6" step="$7" mfact="$8"
+  local sx="$1" sy="$2" x="$3" y="$4" n="$5" step="$6" mfact="$7" leaf_id="$8"
   local split order next axis container
-  local node_a_var="${__out}_a" node_b_var="${__out}_b" first_size second_size
+  local node_a node_b branch_next_id first_size second_size layout
+  local output_next_id output_layout
 
   if [[ "$n" -eq 1 ]]; then
-    _mosaic_layout_leaf "$__out" "$sx" "$sy" "$x" "$y"
+    _mosaic_layout_leaf_at layout "$sx" "$sy" "$x" "$y" "$leaf_id"
+    printf '%s\t%s\n' "$((leaf_id + 1))" "$layout"
     return
   fi
 
@@ -799,34 +810,39 @@ _mosaic_fibonacci_layout_node() {
 
   if [[ "$axis" == "x" ]]; then
     if [[ "$order" == "leaf-node" ]]; then
-      _mosaic_layout_leaf "$node_a_var" "$first_size" "$sy" "$x" "$y"
-      _mosaic_fibonacci_layout_node "$node_b_var" "$second_size" "$sy" "$((x + first_size + 1))" "$y" "$((n - 1))" "$next" "$mfact"
+      _mosaic_layout_leaf_at node_a "$first_size" "$sy" "$x" "$y" "$leaf_id"
+      IFS=$'\t' read -r branch_next_id node_b <<<"$(_mosaic_fibonacci_layout_node "$second_size" "$sy" "$((x + first_size + 1))" "$y" "$((n - 1))" "$next" "$mfact" "$((leaf_id + 1))")"
     else
-      _mosaic_fibonacci_layout_node "$node_a_var" "$first_size" "$sy" "$x" "$y" "$((n - 1))" "$next" "$mfact"
-      _mosaic_layout_leaf "$node_b_var" "$second_size" "$sy" "$((x + first_size + 1))" "$y"
+      IFS=$'\t' read -r branch_next_id node_a <<<"$(_mosaic_fibonacci_layout_node "$first_size" "$sy" "$x" "$y" "$((n - 1))" "$next" "$mfact" "$leaf_id")"
+      _mosaic_layout_leaf_at node_b "$second_size" "$sy" "$((x + first_size + 1))" "$y" "$branch_next_id"
+      branch_next_id=$((branch_next_id + 1))
     fi
   else
     if [[ "$order" == "leaf-node" ]]; then
-      _mosaic_layout_leaf "$node_a_var" "$sx" "$first_size" "$x" "$y"
-      _mosaic_fibonacci_layout_node "$node_b_var" "$sx" "$second_size" "$x" "$((y + first_size + 1))" "$((n - 1))" "$next" "$mfact"
+      _mosaic_layout_leaf_at node_a "$sx" "$first_size" "$x" "$y" "$leaf_id"
+      IFS=$'\t' read -r branch_next_id node_b <<<"$(_mosaic_fibonacci_layout_node "$sx" "$second_size" "$x" "$((y + first_size + 1))" "$((n - 1))" "$next" "$mfact" "$((leaf_id + 1))")"
     else
-      _mosaic_fibonacci_layout_node "$node_a_var" "$sx" "$first_size" "$x" "$y" "$((n - 1))" "$next" "$mfact"
-      _mosaic_layout_leaf "$node_b_var" "$sx" "$second_size" "$x" "$((y + first_size + 1))"
+      IFS=$'\t' read -r branch_next_id node_a <<<"$(_mosaic_fibonacci_layout_node "$sx" "$first_size" "$x" "$y" "$((n - 1))" "$next" "$mfact" "$leaf_id")"
+      _mosaic_layout_leaf_at node_b "$sx" "$second_size" "$x" "$((y + first_size + 1))" "$branch_next_id"
+      branch_next_id=$((branch_next_id + 1))
     fi
   fi
 
   if [[ "$container" == "{}" ]]; then
-    printf -v "$__out" '%sx%s,%s,%s{%s,%s}' "$sx" "$sy" "$x" "$y" "${!node_a_var}" "${!node_b_var}"
+    printf -v layout '%sx%s,%s,%s{%s,%s}' "$sx" "$sy" "$x" "$y" "$node_a" "$node_b"
   else
-    printf -v "$__out" '%sx%s,%s,%s[%s,%s]' "$sx" "$sy" "$x" "$y" "${!node_a_var}" "${!node_b_var}"
+    printf -v layout '%sx%s,%s,%s[%s,%s]' "$sx" "$sy" "$x" "$y" "$node_a" "$node_b"
   fi
+  output_next_id="$branch_next_id"
+  output_layout="$layout"
+  printf '%s\t%s\n' "$output_next_id" "$output_layout"
 }
 
 _mosaic_fibonacci_layout_body() {
   local __out="$1" sx="$2" sy="$3" n="$4" mfact="$5"
   local layout
   _mosaic_layout_leaf_reset
-  _mosaic_fibonacci_layout_node layout "$sx" "$sy" 0 0 "$n" 0 "$mfact"
+  IFS=$'\t' read -r _ layout <<<"$(_mosaic_fibonacci_layout_node "$sx" "$sy" 0 0 "$n" 0 "$mfact" 0)"
   printf -v "$__out" '%s' "$layout"
 }
 

--- a/scripts/layouts/master-stack.sh
+++ b/scripts/layouts/master-stack.sh
@@ -14,34 +14,53 @@ _layout_orientation_for() {
   esac
 }
 
-_layout_layout_for() {
+_layout_orientation_axis_for() {
   case "$1" in
-  left) printf '%s\n' "main-vertical" ;;
-  right) printf '%s\n' "main-vertical-mirrored" ;;
-  top) printf '%s\n' "main-horizontal" ;;
-  bottom) printf '%s\n' "main-horizontal-mirrored" ;;
+  left | right) printf '%s\n' "x" ;;
+  top | bottom) printf '%s\n' "y" ;;
   esac
+}
+
+_layout_orientation_is_mirrored() {
+  case "$1" in
+  right | bottom) return 0 ;;
+  esac
+  return 1
+}
+
+_layout_layout_for() {
+  local orientation="$1" axis suffix=""
+  axis=$(_layout_orientation_axis_for "$orientation")
+  _layout_orientation_is_mirrored "$orientation" && suffix="-mirrored"
+  if [[ "$axis" == "x" ]]; then
+    printf '%s\n' "main-vertical$suffix"
+  else
+    printf '%s\n' "main-horizontal$suffix"
+  fi
 }
 
 _layout_master_pane_option_for() {
-  case "$1" in
-  left | right) printf '%s\n' "main-pane-width" ;;
-  top | bottom) printf '%s\n' "main-pane-height" ;;
-  esac
+  if [[ "$(_layout_orientation_axis_for "$1")" == "x" ]]; then
+    printf '%s\n' "main-pane-width"
+  else
+    printf '%s\n' "main-pane-height"
+  fi
 }
 
 _layout_full_layout_for() {
-  case "$1" in
-  left | right) printf '%s\n' "even-vertical" ;;
-  top | bottom) printf '%s\n' "even-horizontal" ;;
-  esac
+  if [[ "$(_layout_orientation_axis_for "$1")" == "x" ]]; then
+    printf '%s\n' "even-vertical"
+  else
+    printf '%s\n' "even-horizontal"
+  fi
 }
 
 _layout_join_flag_for() {
-  case "$1" in
-  left | right) printf '%s\n' "-v" ;;
-  top | bottom) printf '%s\n' "-h" ;;
-  esac
+  if [[ "$(_layout_orientation_axis_for "$1")" == "x" ]]; then
+    printf '%s\n' "-v"
+  else
+    printf '%s\n' "-h"
+  fi
 }
 
 _layout_apply_layout() {
@@ -62,12 +81,11 @@ _layout_join_extra_masters() {
 }
 
 _layout_new_pane_first_stack() {
-  local win="$1" orientation="$2" target
+  local win="$1" orientation="$2" target axis
   local -a flags=()
   target=$(_mosaic_window_last_pane "$win")
-  case "$orientation" in
-  left | right) flags=(-h) ;;
-  esac
+  axis=$(_layout_orientation_axis_for "$orientation")
+  [[ "$axis" == "x" ]] && flags=(-h)
   _mosaic_new_pane_split_or_append "$win" "$target" "${flags[@]}"
 }
 
@@ -92,38 +110,27 @@ _layout_relayout() {
 }
 
 _layout_new_pane_all_masters() {
-  local win="$1" orientation="$2" n="$3" pbase="$4" target pane
+  local win="$1" orientation="$2" n="$3" pbase="$4" target pane axis
   local -a flags=()
-  case "$orientation" in
-  left)
-    target=$(_mosaic_window_last_pane "$win")
-    flags=(-h)
-    ;;
-  right)
+  axis=$(_layout_orientation_axis_for "$orientation")
+  [[ "$axis" == "x" ]] && flags+=(-h)
+  if _layout_orientation_is_mirrored "$orientation"; then
     target="$win.$pbase"
-    flags=(-h -b)
-    ;;
-  top)
+    flags+=(-b)
+  else
     target=$(_mosaic_window_last_pane "$win")
-    ;;
-  bottom)
-    target="$win.$pbase"
-    flags=(-b)
-    ;;
-  esac
+  fi
   pane=$(_mosaic_new_pane_split_or_append "$win" "$target" "${flags[@]}") || return 1
-  case "$orientation" in
-  right | bottom)
+  if _layout_orientation_is_mirrored "$orientation"; then
     if [[ "$pane" != "$(_mosaic_window_last_pane "$win")" ]]; then
       _mosaic_bubble_keep_focus "$pbase" "$((pbase + n))"
     fi
-    ;;
-  esac
+  fi
   printf '%s\n' "$pane"
 }
 
 _layout_new_pane() {
-  local win n nmaster orientation target pbase
+  local win n nmaster orientation target pbase axis
   local -a flags=()
   win=$(_mosaic_resolve_window "${1:-}")
   n=$(_mosaic_window_pane_count "$win")
@@ -144,9 +151,8 @@ _layout_new_pane() {
     return
   fi
   target=$(_mosaic_window_last_pane "$win")
-  case "$orientation" in
-  top | bottom) flags=(-h) ;;
-  esac
+  axis=$(_layout_orientation_axis_for "$orientation")
+  [[ "$axis" == "y" ]] && flags=(-h)
   _mosaic_new_pane_split_or_append "$win" "$target" "${flags[@]}"
 }
 
@@ -181,19 +187,17 @@ _layout_sync_state() {
   nmaster=$(_mosaic_effective_nmaster "$win" "$n")
   [[ "$nmaster" -ge "$n" ]] && return 0
 
-  local pbase pane_size window_size pct orientation
+  local pbase pane_size window_size pct orientation axis
   orientation=$(_layout_orientation_for "$win")
+  axis=$(_layout_orientation_axis_for "$orientation")
   pbase=$(_mosaic_window_pane_base "$win")
-  case "$orientation" in
-  left | right)
+  if [[ "$axis" == "x" ]]; then
     pane_size=$(tmux display-message -p -t "$win.$pbase" '#{pane_width}' 2>/dev/null)
     window_size=$(tmux display-message -p -t "$win" '#{window_width}' 2>/dev/null)
-    ;;
-  top | bottom)
+  else
     pane_size=$(tmux display-message -p -t "$win.$pbase" '#{pane_height}' 2>/dev/null)
     window_size=$(tmux display-message -p -t "$win" '#{window_height}' 2>/dev/null)
-    ;;
-  esac
+  fi
   [[ -z "$pane_size" ]] && return 0
   [[ -z "$window_size" || "$window_size" -le 0 ]] && return 0
 

--- a/scripts/ops.sh
+++ b/scripts/ops.sh
@@ -148,7 +148,7 @@ fi
 dispatch_optional() {
   local fn="$1" message
   shift
-  if declare -f "$fn" >/dev/null; then
+  if _mosaic_fn_defined "$fn"; then
     "$fn" "$@"
   else
     message="mosaic: $layout does not implement $cmd"
@@ -161,7 +161,7 @@ case "$cmd" in
 relayout | _on-set-option) _layout_relayout "$target_window" ;;
 toggle) _mosaic_toggle_window ;;
 _sync-state)
-  if declare -f _layout_sync_state >/dev/null; then
+  if _mosaic_fn_defined _layout_sync_state; then
     _layout_sync_state "$target_window"
   fi
   ;;
@@ -171,7 +171,7 @@ new-pane)
     exit 1
   fi
   _mosaic_window_structural_guard_set "$target_window" "$RANDOM-$$"
-  if declare -f _layout_new_pane >/dev/null; then
+  if _mosaic_fn_defined _layout_new_pane; then
     pane=$(_layout_new_pane "$target_window")
   else
     pane=$(_mosaic_new_pane_default)
@@ -202,11 +202,11 @@ promote | resize-master)
   fi
   ;;
 '')
-  echo "usage: $0 <op> [args]" >&2
+  printf '%s\n' "usage: $0 <op> [args]" >&2
   exit 1
   ;;
 *)
-  echo "mosaic: unknown op: $cmd" >&2
+  printf '%s\n' "mosaic: unknown op: $cmd" >&2
   exit 1
   ;;
 esac


### PR DESCRIPTION
## Problem

The remaining shell cleanup work still had repeated optional function checks, indirect variable-name expansion in the Fibonacci builder, and duplicated master-stack orientation mapping.

## Solution

Add a shared function-defined helper, make the Fibonacci layout builder thread leaf ids explicitly instead of using indirect expansion, and centralize master-stack axis and mirroring helpers so the same behavior is expressed with less branching and indirection.