### PR TITLE
test(master-stack): stub the live pane-base helper

### DIFF
--- a/tests/integration/new_pane_fast_paths.bats
+++ b/tests/integration/new_pane_fast_paths.bats
@@ -64,7 +64,7 @@ assert_master_stack_all_masters_trace() {
   setup="_mosaic_window_pane_count() { printf '%s\\n' $count; }
 _mosaic_effective_nmaster() { printf '%s\\n' $count; }
 _layout_orientation_for() { printf '%s\\n' $orientation; }
-_layout_pane_base() { printf '%s\\n' 1; }"
+_mosaic_window_pane_base() { printf '%s\\n' 1; }"
 
   run layout_new_pane_trace master-stack t:1 "$setup"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Problem

The all-masters master-stack trace helper was stubbing `_layout_pane_base`, but the layout implementation now reads `_mosaic_window_pane_base`. That left the pure trace tests dependent on ambient tmux state and broke them in CI-like no-tmux runs.

## Solution

Stub `_mosaic_window_pane_base` in the shared trace helper so the tests exercise the same pane-base path as the implementation and stay deterministic without tmux state.
