### PR TITLE
test(master-stack): wait for settled drag-resize state

### DIFF
--- a/tests/integration/master_stack.bats
+++ b/tests/integration/master_stack.bats
@@ -455,7 +455,7 @@ assert_orientation_layout() {
   _mosaic_reset_log
   _mosaic_t resize-pane -t t:1.1 -x 120
   _mosaic_wait_option_changed_from @mosaic-mfact 50 t:1
-  _mosaic_wait_relayout_count_ge 1
+  _mosaic_wait_fingerprint_current t:1
   mfact=$(_mosaic_t show-option -wqv -t t:1 @mosaic-mfact)
   [ "$mfact" -ge 59 ]
   [ "$mfact" -le 61 ]
@@ -489,6 +489,7 @@ assert_orientation_layout() {
   _mosaic_split
   _mosaic_t resize-pane -t t:1.1 -y 30
   _mosaic_wait_option_changed_from @mosaic-mfact 50 t:1
+  _mosaic_wait_fingerprint_current t:1
 
   mfact=$(_mosaic_t show-option -wqv -t t:1 @mosaic-mfact)
   [ "$mfact" -ge 55 ]


### PR DESCRIPTION
## Problem

The `master_stack` drag-resize tests were still waiting for an exact relayout log transition even though drag-resize sync is asynchronous and already covered elsewhere with a looser at-most-one relayout contract. On CI that made the `nmaster 2` path fail even when `@mosaic-mfact` and the later split geometry were correct.

## Solution

Wait for the window fingerprint to settle after the drag-resize mfact change before asserting the synced `@mosaic-mfact` value and the follow-up split geometry. Apply the same stabilization to the top-orientation drag-resize case so both tests wait on settled state instead of exact relayout timing.
