### PR TITLE
ci: add a Forgejo-native quality workflow

### DIFF
--- a/.forgejo/workflows/quality.yaml
+++ b/.forgejo/workflows/quality.yaml
@@ -1,0 +1,30 @@
+name: quality
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  format:
+    name: Format
+    runs-on: tmux-mosaic
+    steps:
+      - uses: actions/checkout@v4
+      - name: Format
+        run: nix develop .#ci --command just format
+  lint:
+    name: Lint
+    runs-on: tmux-mosaic
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lint
+        run: nix develop .#ci --command just lint
+  test:
+    name: Test
+    runs-on: tmux-mosaic
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test
+        run: nix develop .#ci --command just test

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ default:
 format:
     nix fmt -- --ci
     shfmt -i 2 -d mosaic.tmux scripts tests
-    biome format biome.json README.md .github
+    biome format biome.json README.md .forgejo .github
 
 lint:
     shellcheck -x --source-path=SCRIPTDIR --source-path=SCRIPTDIR/scripts mosaic.tmux scripts/*.sh scripts/layouts/*.sh tests/helpers.bash


### PR DESCRIPTION
## Problem

GitHub's `quality.yaml` relies on `cachix/install-nix-action`, which does not resolve in Forgejo Actions. The repo also does not currently format the `.forgejo` workflow directory.

## Solution

Add a Forgejo-native `quality` workflow under `.forgejo/workflows/quality.yaml` that uses the existing Nix toolchain directly, and extend `just format` so `.forgejo` stays inside the repo's formatting surface.