### PR TITLE
test(new_pane): pin layout off in layout_new_pane_direct to remove relayout race

### DIFF
--- a/tests/integration/new_pane_fast_paths.bats
+++ b/tests/integration/new_pane_fast_paths.bats
@@ -13,6 +13,7 @@ teardown() {
 layout_new_pane_direct() {
   local layout="${1:?layout required}" target="${2:-t:1}" sock
   sock=$(_mosaic_socket_path)
+  _mosaic_disable_layout "$target"
   TMUX="$sock,$$,0" bash -c "source '$REPO_ROOT/scripts/helpers.sh'; source '$REPO_ROOT/scripts/layouts/$layout.sh'; _layout_new_pane '$target'"
 }
 


### PR DESCRIPTION
The 21 "before relayout" tests in `new_pane_fast_paths.bats` invoke `layout_new_pane_direct` in a sub-bash to call `_layout_new_pane` (the layout-script function under test) and then assert on the immediate post-split pane geometry. The intent is to verify what `split-window` produces BEFORE the layout's relayout hook fires.

The race is that the relayout hook is async (driven by tmux's pane-creation hook + a fingerprint change), and on faster runners it fires between `_mosaic_wait_pane_present` and `_mosaic_pane_left`, mutating positions out from under the assertions. Test #122 (`grid 2 -> 3 keeps the new pane in the bottom tail before relayout`) flaked twice in CI this way \u2014 once on the initial migration commit, again on the `spark`\u2192`nix` runner-label rename push (`f3897554`).

Pin `@mosaic-layout` to `off` inside `layout_new_pane_direct`, immediately before the sub-bash spawn. The hook still fires after the split, but finds `layout=off` and is a no-op, so positions stay at split-window's assignment for the assertions to read deterministically. The test is still verifying `_layout_new_pane`'s output shape, just without the async-hook contention.

Verified locally: 20/20 consecutive `just test-file new_pane_fast_paths.bats` runs pass, full `just ci` run passes 244/244.